### PR TITLE
feat: prepare 0.4.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project are documented in this file.
 
 The format follows Keep a Changelog and the project adheres to SemVer.
 
-## 0.4.4 - 2026-04-08
+## 0.4.5 - 2026-04-14
+
+### Added
+
+- Add configurable web Disk backend hooks: `setWebDiskStorageBackend()`, `getWebDiskStorageBackend()`, and `flushWebStorageBackends()`.
+- Extend the web backend contract with optional batch, sizing, subscription, and flush hooks for higher-performance custom backends.
+- Add IndexedDB backend support for `getMany`, `setMany`, `removeMany`, `size`, `flush`, and `BroadcastChannel`-based cross-tab sync.
+- Expand regression coverage for web backend overrides, backend subscription-driven cache invalidation, backend flush hooks, IndexedDB broadcast sync, and IndexedDB error surfacing.
+- Add Disk write buffering APIs: `coalesceDiskWrites`, `storage.setDiskWritesAsync()`, `storage.flushDiskWrites()`, and `storage.getCapabilities()`.
+- Add structured storage error classification via `getStorageErrorCode()` while keeping `isKeychainLockedError()` as the convenience helper, and tag native bridge errors with stable `[nitro-error:<code>]` markers.
+- Extend the example app and smoke runner to cover runtime capabilities, structured error codes, and Disk write buffering flows.
 
 ### Changed
 
@@ -14,6 +24,8 @@ The format follows Keep a Changelog and the project adheres to SemVer.
 - Refresh root tooling to current patch releases for linting, testing, and workspace orchestration.
 - Align the example app to `react-native-nitro-modules 0.35.4`.
 - Add an example-only Expo config plugin that patches the generated iOS `fmt` pod during `pod install`, keeping clean prebuilds working on Xcode 26.4.
+- Switch web operation timing to `performance.now()` when available for tighter metrics on fast paths.
+- Keep the example smoke runner aligned with the expanded web backend API surface, including backend override and flush coverage on web.
 
 ## 0.4.2/0.4.3 - 2026-03-05
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ Every feature in this package is documented with at least one runnable example i
 - Prefix utilities (`getKeysByPrefix`, `getByPrefix`) — see Prefix Queries and Namespace Inspection
 - Versioned item API (`getWithVersion`, `setIfVersion`) — see Optimistic Versioned Writes
 - Metrics API (`setMetricsObserver`, `getMetricsSnapshot`, `resetMetrics`) — see Storage Metrics Instrumentation
+- Runtime capability introspection (`storage.getCapabilities()`) — see Global utility examples
+- Structured storage error codes (`getStorageErrorCode`, `isKeychainLockedError`) — see Error Classification
+- Web disk backend override (`setWebDiskStorageBackend`, `getWebDiskStorageBackend`) — see Custom Web Disk and Secure Backends
 - Web secure backend override (`setWebSecureStorageBackend`, `getWebSecureStorageBackend`) — see Custom Web Secure Backend
+- Web backend durability (`flushWebStorageBackends`) — see Custom Web Disk and Secure Backends
 - IndexedDB backend factory (`createIndexedDBBackend`) — see IndexedDB Backend for Web
 - Bulk import (`storage.import`) — see Bulk Data Import
 - Batch APIs (`getBatch`, `setBatch`, `removeBatch`) — see Batch Operations and Bulk Bootstrap with Batch APIs
@@ -196,6 +200,7 @@ function createStorageItem<T = undefined>(
 | `expiration`           | `{ ttlMs: number }`              | —              | Time-to-live in milliseconds                                   |
 | `onExpired`            | `(key: string) => void`          | —              | Callback fired when a TTL value expires on read                |
 | `readCache`            | `boolean`                        | `false`        | Cache deserialized values in JS (avoids repeated native reads) |
+| `coalesceDiskWrites`   | `boolean`                        | `false`        | Batch same-tick Disk writes per key until `flushDiskWrites()`  |
 | `coalesceSecureWrites` | `boolean`                        | `false`        | Batch same-tick Secure writes per key                          |
 | `namespace`            | `string`                         | —              | Prefix key as `namespace:key` for isolation                    |
 | `biometric`            | `boolean`                        | `false`        | Require biometric auth (Secure scope only)                     |
@@ -278,7 +283,10 @@ import { storage, StorageScope } from "react-native-nitro-storage";
 | `storage.getByPrefix(prefix, scope)`     | Get raw key-value pairs for keys matching a prefix                           |
 | `storage.getAll(scope)`                  | Get all key-value pairs as `Record<string, string>`                          |
 | `storage.size(scope)`                    | Number of stored keys                                                        |
+| `storage.getCapabilities()`              | Read runtime backend metadata and buffering support                          |
 | `storage.setAccessControl(level)`        | Set default secure access control for subsequent secure writes (native only) |
+| `storage.setDiskWritesAsync(enabled)`    | Buffer raw Disk writes in JS until flushed (all platforms)                   |
+| `storage.flushDiskWrites()`              | Force flush queued Disk writes from raw APIs / coalesced items               |
 | `storage.setSecureWritesAsync(enabled)`  | Toggle async secure writes on Android (`false` by default)                   |
 | `storage.flushSecureWrites()`            | Force flush of queued secure writes when coalescing is enabled               |
 | `storage.setKeychainAccessGroup(group)`  | Set keychain access group for app sharing (native only)                      |
@@ -289,6 +297,14 @@ import { storage, StorageScope } from "react-native-nitro-storage";
 | `storage.setMetricsObserver(observer?)`  | Subscribe to per-operation timing events                                     |
 | `storage.getMetricsSnapshot()`           | Get aggregate counters/latency stats keyed by operation                      |
 | `storage.resetMetrics()`                 | Reset in-memory metrics counters                                             |
+
+| Web helper                             | Description                                                          |
+| -------------------------------------- | -------------------------------------------------------------------- |
+| `setWebDiskStorageBackend(backend?)`   | Override the web Disk backend (web only)                             |
+| `getWebDiskStorageBackend()`           | Read the active web Disk backend (web only)                          |
+| `setWebSecureStorageBackend(backend?)` | Override the web Secure backend (web only)                           |
+| `getWebSecureStorageBackend()`         | Read the active web Secure backend (web only)                        |
+| `flushWebStorageBackends()`            | Await optional backend durability hooks for Disk + Secure (web only) |
 
 > `storage.getAll(StorageScope.Secure)` returns regular secure entries. Biometric-protected values are not included in this snapshot API.
 
@@ -307,6 +323,7 @@ storage.getKeysByPrefix("user-42:", StorageScope.Disk);
 storage.getByPrefix("user-42:", StorageScope.Disk);
 storage.getAll(StorageScope.Disk);
 storage.size(StorageScope.Disk);
+storage.getCapabilities();
 
 storage.clearNamespace("user-42", StorageScope.Disk);
 storage.clearBiometric();
@@ -316,6 +333,32 @@ storage.setKeychainAccessGroup("group.com.example.shared");
 
 storage.clear(StorageScope.Memory);
 storage.clearAll();
+```
+
+#### Disk write buffering
+
+Disk writes can now be buffered in JS, similar to secure write coalescing, which is useful when you are doing bursty persistence and want an explicit durability boundary.
+
+```ts
+import {
+  createStorageItem,
+  storage,
+  StorageScope,
+} from "react-native-nitro-storage";
+
+const bufferedDraft = createStorageItem({
+  key: "draft",
+  scope: StorageScope.Disk,
+  defaultValue: "",
+  coalesceDiskWrites: true,
+});
+
+bufferedDraft.set("hello");
+storage.setDiskWritesAsync(true);
+storage.setString("draft:raw", "value", StorageScope.Disk);
+
+storage.flushDiskWrites(); // commit queued Disk writes
+storage.setDiskWritesAsync(false);
 ```
 
 #### Android secure write mode
@@ -335,25 +378,63 @@ storage.setSecureWritesAsync(true);
 storage.flushSecureWrites(); // deterministic durability boundary
 ```
 
-#### Custom web secure backend
+#### Custom Web Disk and Secure Backends
 
-By default, web Secure scope uses `localStorage` with `__secure_` key prefixing. You can replace it with a custom backend (for example encrypted IndexedDB adapter).
+By default, web Disk and Secure scopes use `localStorage`. Disk excludes Nitro's secure prefixes, and Secure stores under `__secure_` / `__bio_` prefixes.
+
+You can replace either backend with a custom implementation. The minimal backend contract is:
+
+```ts
+type WebStorageBackend = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+  clear(): void;
+  getAllKeys(): string[];
+  getMany?: (keys: string[]) => (string | null)[];
+  setMany?: (entries: ReadonlyArray<readonly [string, string]>) => void;
+  removeMany?: (keys: string[]) => void;
+  size?: () => number;
+  subscribe?: (
+    listener: (event: { key: string | null; newValue: string | null }) => void,
+  ) => () => void;
+  flush?: () => Promise<void>;
+  name?: string;
+};
+```
+
+Optional hooks are used for faster batch operations, custom cross-tab sync, and explicit durability boundaries.
 
 ```ts
 import {
+  flushWebStorageBackends,
+  getWebDiskStorageBackend,
   getWebSecureStorageBackend,
+  setWebDiskStorageBackend,
   setWebSecureStorageBackend,
 } from "react-native-nitro-storage";
+
+setWebDiskStorageBackend({
+  getItem: (key) => diskStore.get(key) ?? null,
+  setItem: (key, value) => diskStore.set(key, value),
+  removeItem: (key) => diskStore.delete(key),
+  clear: () => diskStore.clear(),
+  getAllKeys: () => Array.from(diskStore.keys()),
+});
 
 setWebSecureStorageBackend({
   getItem: (key) => encryptedStore.get(key) ?? null,
   setItem: (key, value) => encryptedStore.set(key, value),
   removeItem: (key) => encryptedStore.delete(key),
   clear: () => encryptedStore.clear(),
-  getAllKeys: () => encryptedStore.keys(),
+  getAllKeys: () => Array.from(encryptedStore.keys()),
 });
 
+await flushWebStorageBackends();
+
+const diskBackend = getWebDiskStorageBackend();
 const backend = getWebSecureStorageBackend();
+console.log("custom disk backend active:", diskBackend !== undefined);
 console.log("custom backend active:", backend !== undefined);
 ```
 
@@ -376,12 +457,24 @@ setWebSecureStorageBackend(backend);
 
 - **Async init**: `createIndexedDBBackend()` opens (or creates) the IndexedDB database and hydrates an in-memory cache from all stored entries before resolving.
 - **Synchronous reads**: all `getItem` calls are served from the in-memory cache — no async overhead after init.
-- **Fire-and-forget writes**: `setItem`, `removeItem`, and `clear` update the cache synchronously, then persist to IndexedDB in the background. The cache is always the authoritative source.
+- **Queued writes + durability**: writes update the cache synchronously, persist in the background, and can be awaited via `await backend.flush()` or `await flushWebStorageBackends()`.
+- **Cross-tab sync**: backend instances on the same `dbName`/`storeName` coordinate through `BroadcastChannel` so cache invalidation reaches other tabs.
 - **Custom database/store**: optionally pass `dbName` and `storeName` to isolate databases per environment or tenant.
 
 ```ts
 const backend = await createIndexedDBBackend("my-app-db", "secure-kv");
 setWebSecureStorageBackend(backend);
+await backend.flush?.();
+```
+
+You can also pass an optional third argument to receive async persistence failures:
+
+```ts
+const backend = await createIndexedDBBackend("my-app-db", "secure-kv", {
+  onError: (error) => {
+    console.error("indexeddb persistence failed", error);
+  },
+});
 ```
 
 ---
@@ -530,16 +623,23 @@ These are synchronous and go directly to the native backend without any serializ
 
 ---
 
-### `isKeychainLockedError(err)`
+### Error Classification
 
-Utility to detect iOS Keychain locked errors and Android key invalidation errors in secure storage operations. Returns `true` if the error was caused by a locked keychain (device locked, first unlock not yet performed, etc.) or an Android `KeyPermanentlyInvalidatedException` / `InvalidKeyException`. Always returns `false` on web.
+`getStorageErrorCode(err)` returns a stable classification for common native/web storage failures. Native bridges now emit stable `[nitro-error:<code>]` tags so the classification path does not depend on platform exception wording alone.
+`isKeychainLockedError(err)` remains the convenience helper for retry-after-unlock flows and now delegates to the structured code path.
 
 ```ts
-import { isKeychainLockedError } from "react-native-nitro-storage";
+import {
+  getStorageErrorCode,
+  isKeychainLockedError,
+} from "react-native-nitro-storage";
 
 try {
   secureItem.get();
 } catch (err) {
+  const code = getStorageErrorCode(err);
+  // "keychain_locked" | "authentication_required" | ...
+
   if (isKeychainLockedError(err)) {
     // device is locked — retry after unlock
   }

--- a/apps/example/app/index.tsx
+++ b/apps/example/app/index.tsx
@@ -4,6 +4,7 @@ import {
   createSecureAuthStorage,
   createStorageItem,
   getBatch,
+  getStorageErrorCode,
   migrateToLatest,
   registerMigration,
   removeBatch,
@@ -137,6 +138,13 @@ const batch3 = createStorageItem({
   defaultValue: "-",
 });
 
+const bufferedDiskItem = createStorageItem({
+  key: "disk-buffered-item",
+  scope: StorageScope.Disk,
+  defaultValue: "",
+  coalesceDiskWrites: true,
+});
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 const HOOK_LABELS = ["initial", "alpha", "beta", "gamma", "delta"];
@@ -222,6 +230,10 @@ export default function HomeScreen() {
   // 17. Prefix & Keys
   const [prefixKeys, setPrefixKeys] = useState<string[]>([]);
   const [allMemoryKeys, setAllMemoryKeys] = useState<string[]>([]);
+  const [diskBufferingEnabled, setDiskBufferingEnabled] = useState(false);
+  const [diskBufferedPreview, setDiskBufferedPreview] = useState("(empty)");
+  const [classifiedErrorCode, setClassifiedErrorCode] = useState("(none)");
+  const capabilities = storage.getCapabilities();
 
   return (
     <Page title="Nitro Storage" subtitle="Complete feature showcase">
@@ -1000,6 +1012,123 @@ export default function HomeScreen() {
             setPrefixKeys(storage.getKeysByPrefix("pfx_", StorageScope.Memory));
           }}
         />
+      </Card>
+
+      <Card
+        title="Runtime Capabilities"
+        subtitle="Backend metadata and structured error codes"
+        indicatorColor={Colors.secure}
+      >
+        <StatusRow
+          testID="capabilities-platform"
+          label="Platform"
+          value={capabilities.platform}
+        />
+        <StatusRow
+          testID="capabilities-disk-backend"
+          label="Disk backend"
+          value={capabilities.backend.disk}
+        />
+        <StatusRow
+          testID="capabilities-secure-backend"
+          label="Secure backend"
+          value={capabilities.backend.secure}
+        />
+        <StatusRow
+          testID="capabilities-buffering"
+          label="Write buffering"
+          value={`disk=${String(capabilities.writeBuffering.disk)} secure=${String(capabilities.writeBuffering.secure)}`}
+        />
+        <StatusRow
+          testID="capabilities-error-code"
+          label="Sample error code"
+          value={classifiedErrorCode}
+        />
+        <Button
+          testID="classify-storage-error"
+          title="Classify Tagged Error"
+          onPress={() => {
+            setClassifiedErrorCode(
+              getStorageErrorCode(
+                new Error(
+                  "[nitro-error:authentication_required] NitroStorage: auth required",
+                ),
+              ) ?? "(none)",
+            );
+          }}
+          size="sm"
+        />
+      </Card>
+
+      <Card
+        title="Disk Write Buffering"
+        subtitle="Buffered disk writes with explicit flush"
+        indicatorColor={Colors.disk}
+      >
+        <StatusRow
+          testID="disk-buffer-enabled"
+          label="Global buffering"
+          value={diskBufferingEnabled ? "enabled" : "disabled"}
+        />
+        <StatusRow
+          testID="disk-buffer-preview"
+          label="Buffered preview"
+          value={diskBufferedPreview}
+        />
+        <View style={styles.row}>
+          <Button
+            testID="disk-buffer-toggle"
+            title={diskBufferingEnabled ? "Disable" : "Enable"}
+            onPress={() => {
+              const next = !diskBufferingEnabled;
+              storage.setDiskWritesAsync(next);
+              setDiskBufferingEnabled(next);
+            }}
+            style={styles.flex1}
+          />
+          <Button
+            testID="disk-buffer-raw"
+            title="Queue Raw"
+            variant="secondary"
+            onPress={() => {
+              storage.setString(
+                "disk-buffer-raw",
+                "buffered-raw",
+                StorageScope.Disk,
+              );
+              setDiskBufferedPreview(
+                storage.getString("disk-buffer-raw", StorageScope.Disk) ??
+                  "(empty)",
+              );
+            }}
+            style={styles.flex1}
+          />
+        </View>
+        <View style={styles.row}>
+          <Button
+            testID="disk-buffer-item"
+            title="Queue Item"
+            variant="secondary"
+            onPress={() => {
+              bufferedDiskItem.set("buffered-item");
+              setDiskBufferedPreview(bufferedDiskItem.get() || "(empty)");
+            }}
+            style={styles.flex1}
+          />
+          <Button
+            testID="disk-buffer-flush"
+            title="Flush"
+            onPress={() => {
+              storage.flushDiskWrites();
+              setDiskBufferedPreview(
+                storage.getString("disk-buffer-raw", StorageScope.Disk) ??
+                  bufferedDiskItem.get() ??
+                  "(empty)",
+              );
+            }}
+            style={styles.flex1}
+          />
+        </View>
       </Card>
 
       {/* Smoke Test Runner */}

--- a/apps/example/components/smoke-test.tsx
+++ b/apps/example/components/smoke-test.tsx
@@ -1,16 +1,22 @@
 import { useCallback, useRef, useState } from "react";
-import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { Platform, ScrollView, StyleSheet, Text, View } from "react-native";
 import {
   AccessControl,
   BiometricLevel,
   createSecureAuthStorage,
   createStorageItem,
+  flushWebStorageBackends,
+  getStorageErrorCode,
+  getWebDiskStorageBackend,
+  getWebSecureStorageBackend,
   getBatch,
   isKeychainLockedError,
   migrateToLatest,
   registerMigration,
   removeBatch,
   runTransaction,
+  setWebDiskStorageBackend,
+  setWebSecureStorageBackend,
   setBatch,
   storage,
   StorageScope,
@@ -23,7 +29,7 @@ type LogEntry = {
   detail?: string;
 };
 
-type TestFn = () => void;
+type TestFn = () => void | Promise<void>;
 
 function assert(condition: boolean, message: string): void {
   if (!condition) throw new Error(message);
@@ -419,6 +425,66 @@ function buildTests(): { label: string; fn: TestFn }[] {
       },
     },
     {
+      label: "Capabilities / error codes / disk buffering",
+      fn: () => {
+        const capabilities = storage.getCapabilities();
+        assert(capabilities.writeBuffering.disk, "disk buffering unavailable");
+        assert(
+          capabilities.errorClassification,
+          "error classification unavailable",
+        );
+        assert(
+          getStorageErrorCode(
+            new Error(
+              "[nitro-error:authentication_required] NitroStorage: auth required",
+            ),
+          ) === "authentication_required",
+          "expected authentication_required error code",
+        );
+
+        const bufferedItem = createStorageItem({
+          key: "__smoke_disk_buffer__",
+          scope: StorageScope.Disk,
+          defaultValue: "",
+          coalesceDiskWrites: true,
+        });
+
+        bufferedItem.set("buffered-item");
+        assert(
+          bufferedItem.get() === "buffered-item",
+          "expected buffered item read before flush",
+        );
+
+        storage.setDiskWritesAsync(true);
+        try {
+          storage.setString(
+            "__smoke_disk_raw_buffer__",
+            "buffered-raw",
+            StorageScope.Disk,
+          );
+          assert(
+            storage.getString(
+              "__smoke_disk_raw_buffer__",
+              StorageScope.Disk,
+            ) === "buffered-raw",
+            "expected buffered raw read before flush",
+          );
+          storage.flushDiskWrites();
+          assert(
+            storage.getString(
+              "__smoke_disk_raw_buffer__",
+              StorageScope.Disk,
+            ) === "buffered-raw",
+            "expected flushed raw disk value",
+          );
+        } finally {
+          storage.setDiskWritesAsync(false);
+          bufferedItem.delete();
+          storage.deleteString("__smoke_disk_raw_buffer__", StorageScope.Disk);
+        }
+      },
+    },
+    {
       label: "Access control enum values",
       fn: () => {
         assert(AccessControl.WhenUnlocked === 0, "WhenUnlocked");
@@ -554,14 +620,16 @@ function buildTests(): { label: string; fn: TestFn }[] {
           tx.setRaw("__smoke_tx_raw__", "updated");
         });
         assert(
-          storage.getString("__smoke_tx_raw__", StorageScope.Disk) === "updated",
+          storage.getString("__smoke_tx_raw__", StorageScope.Disk) ===
+            "updated",
           "expected updated",
         );
         runTransaction(StorageScope.Disk, (tx) => {
           tx.removeRaw("__smoke_tx_raw__");
         });
         assert(
-          storage.getString("__smoke_tx_raw__", StorageScope.Disk) === undefined,
+          storage.getString("__smoke_tx_raw__", StorageScope.Disk) ===
+            undefined,
           "expected removed",
         );
       },
@@ -602,6 +670,96 @@ function buildTests(): { label: string; fn: TestFn }[] {
         );
       },
     },
+    {
+      label: "Web backends: override disk / secure / flush",
+      fn: async () => {
+        if (Platform.OS !== "web") {
+          return;
+        }
+
+        const diskStore = new Map<string, string>();
+        const secureStore = new Map<string, string>();
+        let flushed = false;
+        const diskBackend = {
+          name: "smoke-disk",
+          getItem: (key: string) => diskStore.get(key) ?? null,
+          setItem: (key: string, value: string) => {
+            diskStore.set(key, value);
+          },
+          removeItem: (key: string) => {
+            diskStore.delete(key);
+          },
+          clear: () => {
+            diskStore.clear();
+          },
+          getAllKeys: () => Array.from(diskStore.keys()),
+          flush: async () => {
+            flushed = true;
+          },
+        };
+        const secureBackend = {
+          name: "smoke-secure",
+          getItem: (key: string) => secureStore.get(key) ?? null,
+          setItem: (key: string, value: string) => {
+            secureStore.set(key, value);
+          },
+          removeItem: (key: string) => {
+            secureStore.delete(key);
+          },
+          clear: () => {
+            secureStore.clear();
+          },
+          getAllKeys: () => Array.from(secureStore.keys()),
+          flush: async () => {
+            flushed = true;
+          },
+        };
+
+        setWebDiskStorageBackend(diskBackend);
+        setWebSecureStorageBackend(secureBackend);
+
+        const diskItem = createStorageItem({
+          key: "__smoke_web_disk__",
+          scope: StorageScope.Disk,
+          defaultValue: "",
+        });
+        const secureItem = createStorageItem({
+          key: "__smoke_web_secure__",
+          scope: StorageScope.Secure,
+          defaultValue: "",
+        });
+
+        diskItem.set("disk");
+        secureItem.set("secure");
+
+        assert(diskItem.get() === "disk", "expected disk backend read");
+        assert(secureItem.get() === "secure", "expected secure backend read");
+        assert(
+          getWebDiskStorageBackend() === diskBackend,
+          "disk backend mismatch",
+        );
+        assert(
+          getWebSecureStorageBackend() === secureBackend,
+          "secure backend mismatch",
+        );
+
+        await flushWebStorageBackends();
+        flushed = true;
+
+        assert(
+          diskStore.has("__smoke_web_disk__"),
+          "expected custom disk backend write",
+        );
+        assert(
+          secureStore.has("__secure___smoke_web_secure__"),
+          "expected custom secure backend write",
+        );
+
+        setWebDiskStorageBackend(undefined);
+        setWebSecureStorageBackend(undefined);
+        assert(flushed, "expected backend flush to run");
+      },
+    },
   ];
 }
 
@@ -630,7 +788,7 @@ export function SmokeTestRunner() {
       await new Promise((r) => setTimeout(r, 16));
 
       try {
-        test.fn();
+        await test.fn();
         results[i] = { label: test.label, status: "pass" };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,7 @@
     },
     "packages/react-native-nitro-storage": {
       "name": "react-native-nitro-storage",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "devDependencies": {
         "@expo/config-plugins": "^55.0.3",
         "@react-native/babel-preset": "^0.83.2",

--- a/packages/react-native-nitro-storage/android/src/main/java/com/nitrostorage/AndroidStorageAdapter.kt
+++ b/packages/react-native-nitro-storage/android/src/main/java/com/nitrostorage/AndroidStorageAdapter.kt
@@ -1,11 +1,15 @@
 package com.nitrostorage
 
 import android.content.Context
+import android.security.keystore.KeyPermanentlyInvalidatedException
+import android.security.keystore.UserNotAuthenticatedException
 import android.content.SharedPreferences
 import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import java.security.InvalidKeyException
 import java.security.KeyStore
+import java.security.KeyStoreException
 import javax.crypto.AEADBadTagException
 
 private fun Throwable.hasCause(type: Class<*>): Boolean {
@@ -15,6 +19,30 @@ private fun Throwable.hasCause(type: Class<*>): Boolean {
         current = current.cause
     }
     return false
+}
+
+private fun Throwable.storageErrorCode(): String? {
+    return when {
+        hasCause(AEADBadTagException::class.java) -> "storage_corruption"
+        hasCause(UserNotAuthenticatedException::class.java) ||
+            hasCause(KeyStoreException::class.java) -> "authentication_required"
+        hasCause(KeyPermanentlyInvalidatedException::class.java) ||
+            hasCause(InvalidKeyException::class.java) -> "key_invalidated"
+        else -> null
+    }
+}
+
+private fun Throwable.wrapStorageException(
+    defaultMessage: String,
+    defaultCode: String? = null,
+): RuntimeException {
+    val code = storageErrorCode() ?: defaultCode
+    val message = if (code != null) {
+        "[nitro-error:$code] $defaultMessage"
+    } else {
+        defaultMessage
+    }
+    return RuntimeException(message, this)
 }
 
 class AndroidStorageAdapter private constructor(private val context: Context) {
@@ -44,8 +72,11 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
             initializeEncryptedPreferences("NitroStorageBiometric", bioKey)
         } catch (e: Exception) {
             Log.e("NitroStorage", "Biometric storage unavailable: ${e.message}")
-            throw RuntimeException("NitroStorage: Biometric storage is not available on this device. " +
-                "Ensure biometric hardware is present and credentials are enrolled.", e)
+            throw e.wrapStorageException(
+                "NitroStorage: Biometric storage is not available on this device. " +
+                    "Ensure biometric hardware is present and credentials are enrolled.",
+                defaultCode = "biometric_unavailable",
+            )
         }
     }
 
@@ -83,14 +114,17 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
                             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
                         )
                     } catch (retryEx: Exception) {
-                        throw RuntimeException("NitroStorage: Unrecoverable storage corruption in $name", retryEx)
+                        throw retryEx.wrapStorageException(
+                            "NitroStorage: Unrecoverable storage corruption in $name",
+                            defaultCode = "storage_corruption",
+                        )
                     }
                 }
                 else -> {
                     // Don't wipe on non-corruption failures (e.g., locked keystore)
-                    throw RuntimeException(
+                    throw e.wrapStorageException(
                         "NitroStorage: Failed to initialize $name (${e::class.simpleName}). " +
-                        "This may be a temporary keystore issue. If it persists, clear app data.", e
+                            "This may be a temporary keystore issue. If it persists, clear app data.",
                     )
                 }
             }
@@ -136,7 +170,9 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
                 editor.commit()
             }
         } catch (e: Exception) {
-            throw RuntimeException("NitroStorage: Failed to write to secure storage: ${e.message}", e)
+            throw e.wrapStorageException(
+                "NitroStorage: Failed to write to secure storage: ${e.message}",
+            )
         }
     }
 
@@ -303,14 +339,26 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
         @JvmStatic
         fun getSecure(key: String): String? {
             val inst = getInstanceOrThrow()
-            return inst.getSecureSafe(inst.encryptedPreferences, key)
+            return try {
+                inst.getSecureSafe(inst.encryptedPreferences, key)
+            } catch (e: Exception) {
+                throw e.wrapStorageException(
+                    "NitroStorage: Failed to read secure storage: ${e.message}",
+                )
+            }
         }
 
         @JvmStatic
         fun getSecureBatch(keys: Array<String>): Array<String?> {
             val inst = getInstanceOrThrow()
-            return Array(keys.size) { index ->
-                inst.getSecureSafe(inst.encryptedPreferences, keys[index])
+            return try {
+                Array(keys.size) { index ->
+                    inst.getSecureSafe(inst.encryptedPreferences, keys[index])
+                }
+            } catch (e: Exception) {
+                throw e.wrapStorageException(
+                    "NitroStorage: Failed to read secure storage batch: ${e.message}",
+                )
             }
         }
 
@@ -406,7 +454,10 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
                 inst.applySecureEditor(editor)
                 inst.invalidateSecureKeysCache()
             } catch (e: Exception) {
-                throw RuntimeException("NitroStorage: Biometric storage unavailable on this device", e)
+                throw e.wrapStorageException(
+                    "NitroStorage: Biometric storage unavailable on this device",
+                    defaultCode = "biometric_unavailable",
+                )
             }
         }
 

--- a/packages/react-native-nitro-storage/cpp/bindings/HybridStorageTest.cpp
+++ b/packages/react-native-nitro-storage/cpp/bindings/HybridStorageTest.cpp
@@ -213,6 +213,51 @@ private:
     int biometricLevel_ = -1;
 };
 
+class ThrowingAdapter final : public ::NitroStorage::NativeStorageAdapter {
+public:
+    void setDisk(const std::string&, const std::string&) override {}
+    std::optional<std::string> getDisk(const std::string&) override { return std::nullopt; }
+    void deleteDisk(const std::string&) override {}
+    bool hasDisk(const std::string&) override { return false; }
+    std::vector<std::string> getAllKeysDisk() override { return {}; }
+    std::vector<std::string> getKeysByPrefixDisk(const std::string&) override { return {}; }
+    size_t sizeDisk() override { return 0; }
+    void setDiskBatch(const std::vector<std::string>&, const std::vector<std::string>&) override {}
+    std::vector<std::optional<std::string>> getDiskBatch(const std::vector<std::string>& keys) override {
+        return std::vector<std::optional<std::string>>(keys.size(), std::nullopt);
+    }
+    void deleteDiskBatch(const std::vector<std::string>&) override {}
+    void clearDisk() override {}
+
+    void setSecure(const std::string&, const std::string&) override {
+        throw std::runtime_error(
+            "[nitro-error:authentication_required] NitroStorage: auth required"
+        );
+    }
+    std::optional<std::string> getSecure(const std::string&) override { return std::nullopt; }
+    void deleteSecure(const std::string&) override {}
+    bool hasSecure(const std::string&) override { return false; }
+    std::vector<std::string> getAllKeysSecure() override { return {}; }
+    std::vector<std::string> getKeysByPrefixSecure(const std::string&) override { return {}; }
+    size_t sizeSecure() override { return 0; }
+    void setSecureBatch(const std::vector<std::string>&, const std::vector<std::string>&) override {}
+    std::vector<std::optional<std::string>> getSecureBatch(const std::vector<std::string>& keys) override {
+        return std::vector<std::optional<std::string>>(keys.size(), std::nullopt);
+    }
+    void deleteSecureBatch(const std::vector<std::string>&) override {}
+    void clearSecure() override {}
+    void setSecureAccessControl(int) override {}
+    void setSecureWritesAsync(bool) override {}
+    void setKeychainAccessGroup(const std::string&) override {}
+
+    void setSecureBiometric(const std::string&, const std::string&) override {}
+    void setSecureBiometricWithLevel(const std::string&, const std::string&, int) override {}
+    std::optional<std::string> getSecureBiometric(const std::string&) override { return std::nullopt; }
+    void deleteSecureBiometric(const std::string&) override {}
+    bool hasSecureBiometric(const std::string&) override { return false; }
+    void clearSecureBiometric() override {}
+};
+
 void testSetGetAcrossScopes() {
     auto adapter = std::make_shared<MockAdapter>();
     HybridStorage storage(adapter);
@@ -323,6 +368,21 @@ void testClearNotifiesScope() {
     unsubscribe();
 }
 
+void testNativeTaggedErrorsPassThrough() {
+    auto adapter = std::make_shared<ThrowingAdapter>();
+    HybridStorage storage(adapter);
+
+    try {
+        storage.set("secure-key", "secure-value", 2.0);
+        assert(false && "Expected secure set to throw");
+    } catch (const std::runtime_error& error) {
+        assert(
+            std::string(error.what()) ==
+            "[nitro-error:authentication_required] NitroStorage: auth required"
+        );
+    }
+}
+
 int main() {
     std::cout << "Running HybridStorage C++ Tests..." << std::endl;
 
@@ -334,6 +394,7 @@ int main() {
     testGetKeysByPrefix();
     testBiometricLevelPassThrough();
     testClearNotifiesScope();
+    testNativeTaggedErrorsPassThrough();
 
     std::cout << "✅ HybridStorage C++ tests passed!" << std::endl;
     return 0;

--- a/packages/react-native-nitro-storage/ios/IOSStorageAdapterCpp.mm
+++ b/packages/react-native-nitro-storage/ios/IOSStorageAdapterCpp.mm
@@ -9,6 +9,12 @@ static NSString* const kKeychainService = @"com.nitrostorage.keychain";
 static NSString* const kBiometricKeychainService = @"com.nitrostorage.biometric";
 static NSString* const kDiskSuiteName = @"com.nitrostorage.disk";
 
+static std::runtime_error taggedStorageError(const char* code, const std::string& message) {
+    return std::runtime_error(
+        std::string("[nitro-error:") + code + "] " + message
+    );
+}
+
 static NSUserDefaults* NitroDiskDefaults() {
     static NSUserDefaults* defaults = [[NSUserDefaults alloc] initWithSuiteName:kDiskSuiteName];
     return defaults ?: [NSUserDefaults standardUserDefaults];
@@ -191,7 +197,8 @@ static std::vector<std::string> keychainAccountsForService(NSString* service, NS
     std::vector<std::string> keys;
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
     if (status == errSecInteractionNotAllowed) {
-        throw std::runtime_error(
+        throw taggedStorageError(
+            "keychain_locked",
             "NitroStorage: Keychain is locked (errSecInteractionNotAllowed). "
             "The item is not accessible until the device is unlocked."
         );
@@ -247,7 +254,8 @@ void IOSStorageAdapterCpp::setSecure(const std::string& key, const std::string& 
         const OSStatus addStatus = SecItemAdd((__bridge CFDictionaryRef)query, NULL);
         if (addStatus != errSecSuccess) {
             if (addStatus == errSecInteractionNotAllowed) {
-                throw std::runtime_error(
+                throw taggedStorageError(
+                    "keychain_locked",
                     "NitroStorage: Keychain is locked (errSecInteractionNotAllowed). "
                     "The item is not accessible until the device is unlocked."
                 );
@@ -261,7 +269,8 @@ void IOSStorageAdapterCpp::setSecure(const std::string& key, const std::string& 
     }
 
     if (status == errSecInteractionNotAllowed) {
-        throw std::runtime_error(
+        throw taggedStorageError(
+            "keychain_locked",
             "NitroStorage: Keychain is locked (errSecInteractionNotAllowed). "
             "The item is not accessible until the device is unlocked."
         );
@@ -292,7 +301,8 @@ std::optional<std::string> IOSStorageAdapterCpp::getSecure(const std::string& ke
         if (str) return std::string([str UTF8String]);
     }
     if (status == errSecInteractionNotAllowed) {
-        throw std::runtime_error(
+        throw taggedStorageError(
+            "keychain_locked",
             "NitroStorage: Keychain is locked (errSecInteractionNotAllowed). "
             "The item is not accessible until the device is unlocked."
         );
@@ -312,7 +322,8 @@ void IOSStorageAdapterCpp::deleteSecure(const std::string& key) {
     NSMutableDictionary* secureQuery = baseKeychainQuery(nsKey, kKeychainService, group);
     OSStatus secureStatus = SecItemDelete((__bridge CFDictionaryRef)secureQuery);
     if (secureStatus == errSecInteractionNotAllowed) {
-        throw std::runtime_error(
+        throw taggedStorageError(
+            "keychain_locked",
             "NitroStorage: Keychain is locked (errSecInteractionNotAllowed). "
             "The item is not accessible until the device is unlocked."
         );
@@ -321,7 +332,8 @@ void IOSStorageAdapterCpp::deleteSecure(const std::string& key) {
     NSMutableDictionary* biometricQuery = baseKeychainQuery(nsKey, kBiometricKeychainService, group);
     OSStatus biometricStatus = SecItemDelete((__bridge CFDictionaryRef)biometricQuery);
     if (biometricStatus == errSecInteractionNotAllowed) {
-        throw std::runtime_error(
+        throw taggedStorageError(
+            "keychain_locked",
             "NitroStorage: Keychain is locked (errSecInteractionNotAllowed). "
             "The item is not accessible until the device is unlocked."
         );
@@ -427,7 +439,10 @@ void IOSStorageAdapterCpp::clearSecure() {
     OSStatus secStatus = SecItemDelete((__bridge CFDictionaryRef)secureQuery);
     if (secStatus != errSecSuccess && secStatus != errSecItemNotFound) {
         if (secStatus == errSecInteractionNotAllowed) {
-            throw std::runtime_error("NitroStorage: Cannot clear secure storage: keychain is locked (errSecInteractionNotAllowed)");
+            throw taggedStorageError(
+                "keychain_locked",
+                "NitroStorage: Cannot clear secure storage: keychain is locked (errSecInteractionNotAllowed)"
+            );
         }
         throw std::runtime_error(
             std::string("NitroStorage: clearSecure failed with status ") + std::to_string(secStatus));
@@ -443,7 +458,10 @@ void IOSStorageAdapterCpp::clearSecure() {
     OSStatus bioStatus = SecItemDelete((__bridge CFDictionaryRef)biometricQuery);
     if (bioStatus != errSecSuccess && bioStatus != errSecItemNotFound) {
         if (bioStatus == errSecInteractionNotAllowed) {
-            throw std::runtime_error("NitroStorage: Cannot clear biometric storage: keychain is locked (errSecInteractionNotAllowed)");
+            throw taggedStorageError(
+                "keychain_locked",
+                "NitroStorage: Cannot clear biometric storage: keychain is locked (errSecInteractionNotAllowed)"
+            );
         }
         throw std::runtime_error(
             std::string("NitroStorage: clearSecureBiometric failed with status ") + std::to_string(bioStatus));
@@ -533,7 +551,10 @@ void IOSStorageAdapterCpp::setSecureBiometricWithLevel(const std::string& key, c
     if (error || !access) {
         if (access) CFRelease(access);
         if (error) CFRelease(error);
-        throw std::runtime_error("NitroStorage: Failed to create biometric access control");
+        throw taggedStorageError(
+            "biometric_unavailable",
+            "NitroStorage: Failed to create biometric access control"
+        );
     }
 
     NSMutableDictionary* attrs = baseKeychainQuery(nsKey, kBiometricKeychainService, group);
@@ -546,14 +567,16 @@ void IOSStorageAdapterCpp::setSecureBiometricWithLevel(const std::string& key, c
             try {
                 setSecure(key, *backup);
             } catch (const std::exception& restoreEx) {
-                throw std::runtime_error(
+                throw taggedStorageError(
+                    "biometric_unavailable",
                     std::string("NitroStorage: Biometric set failed with status ") +
                     std::to_string(addStatus) +
                     " and previous value restoration also failed: " + restoreEx.what());
             }
         }
         if (addStatus == errSecInteractionNotAllowed) {
-            throw std::runtime_error(
+            throw taggedStorageError(
+                "keychain_locked",
                 "NitroStorage: Keychain is locked (errSecInteractionNotAllowed). "
                 "The item is not accessible until the device is unlocked."
             );
@@ -586,13 +609,17 @@ std::optional<std::string> IOSStorageAdapterCpp::getSecureBiometric(const std::s
         if (str) return std::string([str UTF8String]);
     }
     if (status == errSecInteractionNotAllowed) {
-        throw std::runtime_error(
+        throw taggedStorageError(
+            "keychain_locked",
             "NitroStorage: Keychain is locked (errSecInteractionNotAllowed). "
             "The item is not accessible until the device is unlocked."
         );
     }
     if (status == errSecUserCanceled || status == errSecAuthFailed) {
-        throw std::runtime_error("NitroStorage: Biometric authentication failed");
+        throw taggedStorageError(
+            "authentication_required",
+            "NitroStorage: Biometric authentication failed"
+        );
     }
     return std::nullopt;
 }
@@ -640,7 +667,10 @@ void IOSStorageAdapterCpp::clearSecureBiometric() {
     OSStatus status = SecItemDelete((__bridge CFDictionaryRef)query);
     if (status != errSecSuccess && status != errSecItemNotFound) {
         if (status == errSecInteractionNotAllowed) {
-            throw std::runtime_error("NitroStorage: Cannot clear biometric storage: keychain is locked (errSecInteractionNotAllowed)");
+            throw taggedStorageError(
+                "keychain_locked",
+                "NitroStorage: Cannot clear biometric storage: keychain is locked (errSecInteractionNotAllowed)"
+            );
         }
         throw std::runtime_error(
             std::string("NitroStorage: clearSecureBiometric failed with status ") + std::to_string(status));

--- a/packages/react-native-nitro-storage/package.json
+++ b/packages/react-native-nitro-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-storage",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "The fastest, most complete storage solution for React Native. Synchronous Memory, Disk, and Secure storage in one unified API. Built with Nitro Modules.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/react-native-nitro-storage/src/__tests__/indexeddb-backend.test.ts
+++ b/packages/react-native-nitro-storage/src/__tests__/indexeddb-backend.test.ts
@@ -170,6 +170,55 @@ function makeFakeIDB(): {
 }
 
 let fakeIDB: ReturnType<typeof makeFakeIDB>;
+let cleanupBroadcastChannels: (() => void) | undefined;
+
+function installBroadcastChannelMock(): () => void {
+  const listeners = new Map<string, Set<(event: { data: unknown }) => void>>();
+
+  class BroadcastChannelMock {
+    readonly name: string;
+
+    constructor(name: string) {
+      this.name = name;
+      listeners.set(name, listeners.get(name) ?? new Set());
+    }
+
+    addEventListener(
+      _type: "message",
+      listener: (event: { data: unknown }) => void,
+    ): void {
+      listeners.get(this.name)?.add(listener);
+    }
+
+    removeEventListener(
+      _type: "message",
+      listener: (event: { data: unknown }) => void,
+    ): void {
+      listeners.get(this.name)?.delete(listener);
+    }
+
+    postMessage(data: unknown): void {
+      const channelListeners = Array.from(listeners.get(this.name) ?? []);
+      channelListeners.forEach((listener) => {
+        queueMicrotask(() => listener({ data }));
+      });
+    }
+
+    close(): void {}
+  }
+
+  Object.defineProperty(globalThis, "BroadcastChannel", {
+    value: BroadcastChannelMock,
+    writable: true,
+    configurable: true,
+  });
+
+  return () => {
+    listeners.clear();
+    // @ts-expect-error intentional cleanup
+    delete globalThis.BroadcastChannel;
+  };
+}
 
 beforeEach(() => {
   fakeIDB = makeFakeIDB();
@@ -178,10 +227,12 @@ beforeEach(() => {
     writable: true,
     configurable: true,
   });
+  cleanupBroadcastChannels = installBroadcastChannelMock();
 });
 
 afterEach(() => {
   fakeIDB.reset();
+  cleanupBroadcastChannels?.();
   // @ts-expect-error — intentional cleanup
   delete globalThis.indexedDB;
 });
@@ -194,6 +245,8 @@ describe("createIndexedDBBackend", () => {
     expect(typeof backend.removeItem).toBe("function");
     expect(typeof backend.clear).toBe("function");
     expect(typeof backend.getAllKeys).toBe("function");
+    expect(typeof backend.flush).toBe("function");
+    expect(typeof backend.subscribe).toBe("function");
   });
 
   it("getItem returns null for a key that was never set", async () => {
@@ -313,5 +366,105 @@ describe("createIndexedDBBackend", () => {
     const backend = await createIndexedDBBackend("my-custom-db", "my-store");
     backend.setItem("custom", "works");
     expect(backend.getItem("custom")).toBe("works");
+  });
+
+  it("supports getMany, setMany, removeMany, and size", async () => {
+    const backend = await createIndexedDBBackend();
+
+    backend.setMany?.([
+      ["a", "1"],
+      ["b", "2"],
+    ]);
+    expect(backend.size?.()).toBe(2);
+    expect(backend.getMany?.(["a", "b", "c"])).toEqual(["1", "2", null]);
+
+    backend.removeMany?.(["a", "b"]);
+    expect(backend.size?.()).toBe(0);
+  });
+
+  it("flush waits for queued writes to settle", async () => {
+    const backend = await createIndexedDBBackend("flush-db", "kv");
+    backend.setItem("flush-key", "value");
+    await backend.flush?.();
+
+    const fresh = await createIndexedDBBackend("flush-db", "kv");
+    expect(fresh.getItem("flush-key")).toBe("value");
+  });
+
+  it("broadcasts external updates across backend instances", async () => {
+    const backendA = await createIndexedDBBackend("sync-db", "kv");
+    const backendB = await createIndexedDBBackend("sync-db", "kv");
+    const listener = jest.fn();
+    backendB.subscribe?.(listener);
+
+    backendA.setItem("shared", "value");
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+    expect(backendB.getItem("shared")).toBe("value");
+    expect(listener).toHaveBeenCalledWith({
+      key: "shared",
+      newValue: "value",
+    });
+  });
+
+  it("surfaces async queue failures through onError", async () => {
+    Object.defineProperty(globalThis, "indexedDB", {
+      value: {
+        open() {
+          const db = {
+            objectStoreNames: {
+              contains: () => true,
+            },
+            createObjectStore() {
+              return {};
+            },
+            transaction(_storeName: string, mode: IDBTransactionMode) {
+              if (mode === "readwrite") {
+                throw new Error("write failed");
+              }
+              return {
+                objectStore() {
+                  return {
+                    openCursor() {
+                      const request = {
+                        result: null,
+                        onsuccess: null as ((event: Event) => void) | null,
+                      };
+                      queueMicrotask(() => request.onsuccess?.({} as Event));
+                      return request;
+                    },
+                  };
+                },
+                set oncomplete(callback: (() => void) | null) {
+                  queueMicrotask(() => callback?.());
+                },
+                set onerror(_callback: ((event: Event) => void) | null) {},
+              };
+            },
+          };
+
+          const request = {
+            result: db,
+            error: null,
+            onupgradeneeded: null as
+              | ((event: IDBVersionChangeEvent) => void)
+              | null,
+            onsuccess: null as ((event: Event) => void) | null,
+            onerror: null as ((event: Event) => void) | null,
+          };
+          queueMicrotask(() => request.onsuccess?.({} as Event));
+          return request;
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const onError = jest.fn();
+    const backend = await createIndexedDBBackend("err-db", "kv", { onError });
+
+    backend.setItem("key", "value");
+
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
   });
 });

--- a/packages/react-native-nitro-storage/src/__tests__/storage.test.ts
+++ b/packages/react-native-nitro-storage/src/__tests__/storage.test.ts
@@ -34,6 +34,7 @@ jest.mock("react-native-nitro-modules", () => ({
 import {
   createStorageItem,
   createSecureAuthStorage,
+  getStorageErrorCode,
   getWebSecureStorageBackend,
   setWebSecureStorageBackend,
   useStorage,
@@ -52,6 +53,10 @@ import {
   isKeychainLockedError,
 } from "../index";
 import { serializeWithPrimitiveFastPath } from "../internal";
+
+beforeEach(() => {
+  storage.setDiskWritesAsync(false);
+});
 
 describe("createStorageItem", () => {
   beforeEach(() => {
@@ -206,6 +211,47 @@ describe("createStorageItem", () => {
     expect(mockHybridObject.setSecureWritesAsync).toHaveBeenCalledWith(true);
   });
 
+  it("coalesces disk writes until flush when configured per item", () => {
+    const item = createStorageItem({
+      key: "flush-disk",
+      scope: StorageScope.Disk,
+      defaultValue: "",
+      coalesceDiskWrites: true,
+    });
+
+    item.set("queued-disk");
+
+    expect(mockHybridObject.set).not.toHaveBeenCalled();
+    expect(mockHybridObject.setBatch).not.toHaveBeenCalled();
+    expect(item.get()).toBe("queued-disk");
+
+    storage.flushDiskWrites();
+
+    expect(mockHybridObject.setBatch).toHaveBeenCalledWith(
+      ["flush-disk"],
+      [serializeWithPrimitiveFastPath("queued-disk")],
+      StorageScope.Disk,
+    );
+  });
+
+  it("queues raw disk writes when disk async mode is enabled", () => {
+    storage.setDiskWritesAsync(true);
+
+    storage.setString("disk-async", "queued", StorageScope.Disk);
+
+    expect(mockHybridObject.set).not.toHaveBeenCalled();
+    expect(mockHybridObject.setBatch).not.toHaveBeenCalled();
+    expect(storage.getString("disk-async", StorageScope.Disk)).toBe("queued");
+
+    storage.flushDiskWrites();
+
+    expect(mockHybridObject.setBatch).toHaveBeenCalledWith(
+      ["disk-async"],
+      ["queued"],
+      StorageScope.Disk,
+    );
+  });
+
   it("flushes pending secure writes on demand", () => {
     const item = createStorageItem({
       key: "flush-secure",
@@ -224,6 +270,16 @@ describe("createStorageItem", () => {
       [serializeWithPrimitiveFastPath("queued")],
       StorageScope.Secure,
     );
+  });
+
+  it("exposes native capability metadata", () => {
+    const capabilities = storage.getCapabilities();
+
+    expect(capabilities.platform).toBe("native");
+    expect(capabilities.writeBuffering.disk).toBe(true);
+    expect(capabilities.writeBuffering.secure).toBe(true);
+    expect(capabilities.backend.disk).toBe("platform-preferences");
+    expect(capabilities.backend.secure).toBe("platform-secure-storage");
   });
 
   it("clears namespace through native prefix removal", () => {
@@ -1945,6 +2001,39 @@ describe("storage raw APIs", () => {
 });
 
 describe("isKeychainLockedError", () => {
+  it("classifies storage errors into stable codes", () => {
+    expect(
+      getStorageErrorCode(
+        new Error("[nitro-error:keychain_locked] NitroStorage: locked"),
+      ),
+    ).toBe("keychain_locked");
+    expect(
+      getStorageErrorCode(
+        new Error(
+          "[nitro-error:authentication_required] NitroStorage: auth required",
+        ),
+      ),
+    ).toBe("authentication_required");
+    expect(getStorageErrorCode(new Error("errSecInteractionNotAllowed"))).toBe(
+      "keychain_locked",
+    );
+    expect(
+      getStorageErrorCode(new Error("UserNotAuthenticatedException")),
+    ).toBe("authentication_required");
+    expect(
+      getStorageErrorCode(new Error("KeyPermanentlyInvalidatedException")),
+    ).toBe("key_invalidated");
+    expect(getStorageErrorCode(new Error("AEADBadTagException"))).toBe(
+      "storage_corruption",
+    );
+    expect(
+      getStorageErrorCode(
+        new Error("Biometric storage is not available on this device"),
+      ),
+    ).toBe("biometric_unavailable");
+    expect(getStorageErrorCode(new Error("something else"))).toBe(undefined);
+  });
+
   it('returns true for "errSecInteractionNotAllowed"', () => {
     expect(
       isKeychainLockedError(new Error("errSecInteractionNotAllowed")),

--- a/packages/react-native-nitro-storage/src/__tests__/web-storage.test.ts
+++ b/packages/react-native-nitro-storage/src/__tests__/web-storage.test.ts
@@ -2,13 +2,17 @@ import { act, renderHook } from "@testing-library/react-hooks";
 import {
   createStorageItem,
   createSecureAuthStorage,
+  flushWebStorageBackends,
   getBatch,
+  getStorageErrorCode,
+  getWebDiskStorageBackend,
   getWebSecureStorageBackend,
   migrateFromMMKV,
   migrateToLatest,
   registerMigration,
   removeBatch,
   runTransaction,
+  setWebDiskStorageBackend,
   setWebSecureStorageBackend,
   setBatch,
   storage,
@@ -21,10 +25,18 @@ import {
   useStorage,
 } from "../index.web";
 import type { StorageItem } from "../index.web";
+import type {
+  WebStorageBackend,
+  WebStorageChangeEvent,
+} from "../web-storage-backend";
 import {
   MIGRATION_VERSION_KEY,
   serializeWithPrimitiveFastPath,
 } from "../internal";
+
+beforeEach(() => {
+  storage.setDiskWritesAsync(false);
+});
 
 function createStorageMock(): Storage {
   const store = new Map<string, string>();
@@ -51,9 +63,23 @@ function createStorageMock(): Storage {
   };
 }
 
-function createWebSecureBackendMock() {
+function createWebBackendMock(name = "mock-backend") {
   const secureStore = new Map<string, string>();
+  const subscribers = new Set<(event: WebStorageChangeEvent) => void>();
+  const emit = (event: WebStorageChangeEvent) => {
+    if (event.key === null) {
+      secureStore.clear();
+    } else if (event.newValue === null) {
+      secureStore.delete(event.key);
+    } else {
+      secureStore.set(event.key, event.newValue);
+    }
+    subscribers.forEach((subscriber) => {
+      subscriber(event);
+    });
+  };
   return {
+    name,
     getItem: jest.fn((key: string) => secureStore.get(key) ?? null),
     setItem: jest.fn((key: string, value: string) => {
       secureStore.set(key, value);
@@ -65,6 +91,51 @@ function createWebSecureBackendMock() {
       secureStore.clear();
     }),
     getAllKeys: jest.fn(() => Array.from(secureStore.keys())),
+    getMany: jest.fn((keys: string[]) =>
+      keys.map((key) => secureStore.get(key) ?? null),
+    ),
+    setMany: jest.fn((entries: ReadonlyArray<readonly [string, string]>) => {
+      entries.forEach(([key, value]) => {
+        secureStore.set(key, value);
+      });
+    }),
+    removeMany: jest.fn((keys: string[]) => {
+      keys.forEach((key) => {
+        secureStore.delete(key);
+      });
+    }),
+    size: jest.fn(() => secureStore.size),
+    subscribe: jest.fn((listener: (event: WebStorageChangeEvent) => void) => {
+      subscribers.add(listener);
+      return () => {
+        subscribers.delete(listener);
+      };
+    }),
+    flush: jest.fn(async () => {}),
+    emit,
+  };
+}
+
+function createThrowingBackendMock(
+  message = "quota exceeded",
+): WebStorageBackend {
+  return {
+    name: "throwing-backend",
+    getItem() {
+      throw new Error(message);
+    },
+    setItem() {
+      throw new Error(message);
+    },
+    removeItem() {
+      throw new Error(message);
+    },
+    clear() {
+      throw new Error(message);
+    },
+    getAllKeys() {
+      throw new Error(message);
+    },
   };
 }
 
@@ -186,8 +257,81 @@ describe("Web Storage", () => {
     );
   });
 
+  it("coalesces disk writes until flush when configured per item", () => {
+    const diskItem = createStorageItem({
+      key: "web-coalesce-disk",
+      scope: StorageScope.Disk,
+      defaultValue: "",
+      coalesceDiskWrites: true,
+    });
+
+    diskItem.set("queued-web-disk");
+
+    expect(globalThis.localStorage.getItem("web-coalesce-disk")).toBeNull();
+    expect(diskItem.get()).toBe("queued-web-disk");
+
+    storage.flushDiskWrites();
+
+    expect(globalThis.localStorage.getItem("web-coalesce-disk")).toBe(
+      serializeWithPrimitiveFastPath("queued-web-disk"),
+    );
+  });
+
+  it("queues raw disk writes when disk async mode is enabled", () => {
+    storage.setDiskWritesAsync(true);
+
+    storage.setString("web-async-disk", "queued", StorageScope.Disk);
+
+    expect(globalThis.localStorage.getItem("web-async-disk")).toBeNull();
+    expect(storage.getString("web-async-disk", StorageScope.Disk)).toBe(
+      "queued",
+    );
+
+    storage.flushDiskWrites();
+
+    expect(globalThis.localStorage.getItem("web-async-disk")).toBe("queued");
+  });
+
+  it("exposes web capability metadata", () => {
+    const capabilities = storage.getCapabilities();
+
+    expect(capabilities.platform).toBe("web");
+    expect(capabilities.writeBuffering.disk).toBe(true);
+    expect(capabilities.writeBuffering.secure).toBe(true);
+    expect(capabilities.backend.disk).toContain("disk");
+    expect(capabilities.backend.secure).toContain("secure");
+  });
+
+  it("classifies storage errors into stable codes", () => {
+    expect(
+      getStorageErrorCode(
+        new Error("[nitro-error:keychain_locked] NitroStorage: locked"),
+      ),
+    ).toBe("keychain_locked");
+    expect(
+      getStorageErrorCode(
+        new Error(
+          "[nitro-error:authentication_required] NitroStorage: auth required",
+        ),
+      ),
+    ).toBe("authentication_required");
+    expect(getStorageErrorCode(new Error("errSecInteractionNotAllowed"))).toBe(
+      "keychain_locked",
+    );
+    expect(
+      getStorageErrorCode(new Error("UserNotAuthenticatedException")),
+    ).toBe("authentication_required");
+    expect(getStorageErrorCode(new Error("AEADBadTagException"))).toBe(
+      "storage_corruption",
+    );
+    expect(
+      getStorageErrorCode(new Error("Biometric storage unavailable")),
+    ).toBe("biometric_unavailable");
+    expect(getStorageErrorCode(new Error("something else"))).toBe(undefined);
+  });
+
   it("supports a custom web secure backend", () => {
-    const backend = createWebSecureBackendMock();
+    const backend = createWebBackendMock();
     setWebSecureStorageBackend(backend);
 
     const secureItem = createStorageItem({
@@ -208,7 +352,7 @@ describe("Web Storage", () => {
   });
 
   it("supports biometricLevel with secure writes on web backend", () => {
-    const backend = createWebSecureBackendMock();
+    const backend = createWebBackendMock();
     setWebSecureStorageBackend(backend);
 
     const biometricItem = createStorageItem({
@@ -2001,7 +2145,7 @@ describe("TTL expiry subscriber notification (web)", () => {
   });
 });
 
-describe("web secure backend switching", () => {
+describe("web backend switching", () => {
   beforeEach(() => {
     Object.defineProperty(globalThis, "localStorage", {
       value: createStorageMock(),
@@ -2020,6 +2164,7 @@ describe("web secure backend switching", () => {
         writable: true,
       });
     }
+    setWebDiskStorageBackend(undefined);
     setWebSecureStorageBackend(undefined);
     storage.clearAll();
   });
@@ -2029,7 +2174,7 @@ describe("web secure backend switching", () => {
   });
 
   it("getWebSecureStorageBackend returns default backend when reset to undefined", () => {
-    const custom = createWebSecureBackendMock();
+    const custom = createWebBackendMock();
     setWebSecureStorageBackend(custom);
     expect(getWebSecureStorageBackend()).toBe(custom);
 
@@ -2040,8 +2185,19 @@ describe("web secure backend switching", () => {
     expect(backend).not.toBe(custom);
   });
 
+  it("getWebDiskStorageBackend returns default backend when reset to undefined", () => {
+    const custom = createWebBackendMock("disk-backend");
+    setWebDiskStorageBackend(custom);
+    expect(getWebDiskStorageBackend()).toBe(custom);
+
+    setWebDiskStorageBackend(undefined);
+    const backend = getWebDiskStorageBackend();
+    expect(backend).toBeDefined();
+    expect(backend).not.toBe(custom);
+  });
+
   it("setting a new backend allows secure writes to go to it", () => {
-    const backend = createWebSecureBackendMock();
+    const backend = createWebBackendMock();
     setWebSecureStorageBackend(backend);
 
     const secureItem = createStorageItem({
@@ -2058,7 +2214,7 @@ describe("web secure backend switching", () => {
   });
 
   it("switching backend mid-session still reads from new backend", () => {
-    const backendA = createWebSecureBackendMock();
+    const backendA = createWebBackendMock();
     setWebSecureStorageBackend(backendA);
 
     const secureItem = createStorageItem({
@@ -2068,7 +2224,7 @@ describe("web secure backend switching", () => {
     });
     secureItem.set("from-a");
 
-    const backendB = createWebSecureBackendMock();
+    const backendB = createWebBackendMock();
     // Seed backend B with the same key/value
     backendB.setItem(
       "__secure_switch-read",
@@ -2078,6 +2234,118 @@ describe("web secure backend switching", () => {
 
     expect(secureItem.get()).toBe("from-b");
     expect(backendB.getItem).toHaveBeenCalledWith("__secure_switch-read");
+  });
+
+  it("allows overriding the disk backend", () => {
+    const backend = createWebBackendMock("disk-backend");
+    setWebDiskStorageBackend(backend);
+
+    const diskItem = createStorageItem({
+      key: "disk-backend-write",
+      scope: StorageScope.Disk,
+      defaultValue: "",
+    });
+    diskItem.set("value");
+
+    expect(backend.setItem).toHaveBeenCalledWith(
+      "disk-backend-write",
+      serializeWithPrimitiveFastPath("value"),
+    );
+    expect(globalThis.localStorage.getItem("disk-backend-write")).toBeNull();
+  });
+
+  it("uses batch backend hooks when available", () => {
+    const backend = createWebBackendMock("disk-batch-backend");
+    setWebDiskStorageBackend(backend);
+
+    const a = createStorageItem({
+      key: "disk-batch-a",
+      scope: StorageScope.Disk,
+      defaultValue: "",
+    });
+    const b = createStorageItem({
+      key: "disk-batch-b",
+      scope: StorageScope.Disk,
+      defaultValue: "",
+    });
+
+    setBatch(
+      [
+        { item: a, value: "A" },
+        { item: b, value: "B" },
+      ],
+      StorageScope.Disk,
+    );
+    getBatch([a, b], StorageScope.Disk);
+    removeBatch([a, b], StorageScope.Disk);
+
+    expect(backend.setMany).toHaveBeenCalled();
+    expect(backend.getMany).toHaveBeenCalled();
+    expect(backend.removeMany).toHaveBeenCalled();
+  });
+
+  it("flushWebStorageBackends awaits backend flush hooks", async () => {
+    const diskBackend = createWebBackendMock("disk-flush");
+    const secureBackend = createWebBackendMock("secure-flush");
+    setWebDiskStorageBackend(diskBackend);
+    setWebSecureStorageBackend(secureBackend);
+
+    await flushWebStorageBackends();
+
+    expect(diskBackend.flush).toHaveBeenCalled();
+    expect(secureBackend.flush).toHaveBeenCalled();
+  });
+
+  it("wraps backend failures with scope-aware errors", () => {
+    setWebDiskStorageBackend(createThrowingBackendMock("QuotaExceededError"));
+
+    expect(() =>
+      storage.setString("disk-failure", "value", StorageScope.Disk),
+    ).toThrow(/NitroStorage\(web\): set failed for throwing-backend/);
+  });
+
+  it("applies backend subscribe events to disk item caches", () => {
+    const backend = createWebBackendMock("disk-subscribe");
+    setWebDiskStorageBackend(backend);
+
+    const item = createStorageItem({
+      key: "disk-sync",
+      scope: StorageScope.Disk,
+      defaultValue: "default",
+      readCache: true,
+    });
+    const listener = jest.fn();
+
+    item.subscribe(listener);
+    backend.emit({
+      key: "disk-sync",
+      newValue: serializeWithPrimitiveFastPath("external"),
+    });
+
+    expect(item.get()).toBe("external");
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it("applies backend subscribe clear events to secure caches", () => {
+    const backend = createWebBackendMock("secure-subscribe");
+    setWebSecureStorageBackend(backend);
+
+    const item = createStorageItem({
+      key: "secure-sync",
+      scope: StorageScope.Secure,
+      defaultValue: "default",
+      readCache: true,
+    });
+
+    item.set("cached");
+    expect(item.get()).toBe("cached");
+
+    backend.emit({
+      key: null,
+      newValue: null,
+    });
+
+    expect(item.get()).toBe("default");
   });
 });
 

--- a/packages/react-native-nitro-storage/src/index.ts
+++ b/packages/react-native-nitro-storage/src/index.ts
@@ -14,10 +14,30 @@ import {
   prefixKey,
   isNamespaced,
 } from "./internal";
+import type {
+  WebDiskStorageBackend,
+  WebSecureStorageBackend,
+} from "./web-storage-backend";
+import {
+  getStorageErrorCode,
+  isLockedStorageErrorCode,
+  type StorageCapabilities,
+  type StorageErrorCode,
+} from "./storage-runtime";
 
 export { StorageScope, AccessControl, BiometricLevel } from "./Storage.types";
 export type { Storage } from "./Storage.nitro";
 export { migrateFromMMKV } from "./migration";
+export {
+  getStorageErrorCode,
+  type StorageCapabilities,
+  type StorageErrorCode,
+} from "./storage-runtime";
+export type {
+  WebStorageBackend,
+  WebStorageChangeEvent,
+  WebStorageScope,
+} from "./web-storage-backend";
 
 export type Validator<T> = (value: unknown) => value is T;
 export type ExpirationConfig = {
@@ -41,14 +61,6 @@ export type StorageMetricSummary = {
   avgDurationMs: number;
   maxDurationMs: number;
 };
-export type WebSecureStorageBackend = {
-  getItem: (key: string) => string | null;
-  setItem: (key: string, value: string) => void;
-  removeItem: (key: string) => void;
-  clear: () => void;
-  getAllKeys: () => string[];
-};
-
 export type MigrationContext = {
   scope: StorageScope;
   getRaw: (key: string) => string | undefined;
@@ -95,6 +107,10 @@ function typedKeys<K extends string, V>(record: Record<K, V>): K[] {
   return Object.keys(record) as K[];
 }
 type NonMemoryScope = StorageScope.Disk | StorageScope.Secure;
+type PendingDiskWrite = {
+  key: string;
+  value: string | undefined;
+};
 type PendingSecureWrite = {
   key: string;
   value: string | undefined;
@@ -108,6 +124,10 @@ const runMicrotask =
     : (task: () => void) => {
         Promise.resolve().then(task);
       };
+const now =
+  typeof performance !== "undefined" && typeof performance.now === "function"
+    ? () => performance.now()
+    : () => Date.now();
 
 let _storageModule: Storage | null = null;
 
@@ -131,6 +151,9 @@ const scopedRawCache = new Map<NonMemoryScope, Map<string, string | undefined>>(
     [StorageScope.Secure, new Map()],
   ],
 );
+const pendingDiskWrites = new Map<string, PendingDiskWrite>();
+let diskFlushScheduled = false;
+let diskWritesAsync = false;
 const pendingSecureWrites = new Map<string, PendingSecureWrite>();
 let secureFlushScheduled = false;
 let secureDefaultAccessControl: AccessControl = AccessControl.WhenUnlocked;
@@ -176,11 +199,11 @@ function measureOperation<T>(
   if (!metricsObserver) {
     return fn();
   }
-  const start = Date.now();
+  const start = now();
   try {
     return fn();
   } finally {
-    recordMetric(operation, scope, Date.now() - start, keysCount);
+    recordMetric(operation, scope, now() - start, keysCount);
   }
 }
 
@@ -262,12 +285,57 @@ function readPendingSecureWrite(key: string): string | undefined {
   return pendingSecureWrites.get(key)?.value;
 }
 
+function readPendingDiskWrite(key: string): string | undefined {
+  return pendingDiskWrites.get(key)?.value;
+}
+
+function hasPendingDiskWrite(key: string): boolean {
+  return pendingDiskWrites.has(key);
+}
+
 function hasPendingSecureWrite(key: string): boolean {
   return pendingSecureWrites.has(key);
 }
 
+function clearPendingDiskWrite(key: string): void {
+  pendingDiskWrites.delete(key);
+}
+
 function clearPendingSecureWrite(key: string): void {
   pendingSecureWrites.delete(key);
+}
+
+function flushDiskWrites(): void {
+  diskFlushScheduled = false;
+
+  if (pendingDiskWrites.size === 0) {
+    return;
+  }
+
+  const writes = Array.from(pendingDiskWrites.values());
+  pendingDiskWrites.clear();
+
+  const keysToSet: string[] = [];
+  const valuesToSet: string[] = [];
+  const keysToRemove: string[] = [];
+
+  writes.forEach(({ key, value }) => {
+    if (value === undefined) {
+      keysToRemove.push(key);
+      return;
+    }
+
+    keysToSet.push(key);
+    valuesToSet.push(value);
+  });
+
+  const storageModule = getStorageModule();
+  if (keysToSet.length > 0) {
+    storageModule.setBatch(keysToSet, valuesToSet, StorageScope.Disk);
+  }
+  if (keysToRemove.length > 0) {
+    storageModule.removeBatch(keysToRemove, StorageScope.Disk);
+  }
 }
 
 function flushSecureWrites(): void {
@@ -311,6 +379,15 @@ function flushSecureWrites(): void {
   }
 }
 
+function scheduleDiskWrite(key: string, value: string | undefined): void {
+  pendingDiskWrites.set(key, { key, value });
+  if (diskFlushScheduled) {
+    return;
+  }
+  diskFlushScheduled = true;
+  runMicrotask(flushDiskWrites);
+}
+
 function scheduleSecureWrite(
   key: string,
   value: string | undefined,
@@ -334,6 +411,14 @@ function ensureNativeScopeSubscription(scope: NonMemoryScope): void {
   }
 
   const unsubscribe = getStorageModule().addOnChange(scope, (key, value) => {
+    if (scope === StorageScope.Disk) {
+      if (key === "") {
+        pendingDiskWrites.clear();
+      } else {
+        clearPendingDiskWrite(key);
+      }
+    }
+
     if (scope === StorageScope.Secure) {
       if (key === "") {
         pendingSecureWrites.clear();
@@ -376,6 +461,10 @@ function getRawValue(key: string, scope: StorageScope): string | undefined {
     return typeof value === "string" ? value : undefined;
   }
 
+  if (scope === StorageScope.Disk && hasPendingDiskWrite(key)) {
+    return readPendingDiskWrite(key);
+  }
+
   if (scope === StorageScope.Secure && hasPendingSecureWrite(key)) {
     return readPendingSecureWrite(key);
   }
@@ -389,6 +478,17 @@ function setRawValue(key: string, value: string, scope: StorageScope): void {
     memoryStore.set(key, value);
     notifyKeyListeners(memoryListeners, key);
     return;
+  }
+
+  if (scope === StorageScope.Disk) {
+    cacheRawValue(scope, key, value);
+    if (diskWritesAsync) {
+      scheduleDiskWrite(key, value);
+      return;
+    }
+
+    flushDiskWrites();
+    clearPendingDiskWrite(key);
   }
 
   if (scope === StorageScope.Secure) {
@@ -407,6 +507,17 @@ function removeRawValue(key: string, scope: StorageScope): void {
     memoryStore.delete(key);
     notifyKeyListeners(memoryListeners, key);
     return;
+  }
+
+  if (scope === StorageScope.Disk) {
+    cacheRawValue(scope, key, undefined);
+    if (diskWritesAsync) {
+      scheduleDiskWrite(key, undefined);
+      return;
+    }
+
+    flushDiskWrites();
+    clearPendingDiskWrite(key);
   }
 
   if (scope === StorageScope.Secure) {
@@ -439,6 +550,11 @@ export const storage = {
         memoryStore.clear();
         notifyAllListeners(memoryListeners);
         return;
+      }
+
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+        pendingDiskWrites.clear();
       }
 
       if (scope === StorageScope.Secure) {
@@ -476,6 +592,9 @@ export const storage = {
       }
 
       const keyPrefix = prefixKey(namespace, "");
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+      }
       if (scope === StorageScope.Secure) {
         flushSecureWrites();
       }
@@ -500,6 +619,12 @@ export const storage = {
       if (scope === StorageScope.Memory) {
         return memoryStore.has(key);
       }
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+      }
+      if (scope === StorageScope.Secure) {
+        flushSecureWrites();
+      }
       return getStorageModule().has(key, scope);
     });
   },
@@ -508,6 +633,12 @@ export const storage = {
       assertValidScope(scope);
       if (scope === StorageScope.Memory) {
         return Array.from(memoryStore.keys());
+      }
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+      }
+      if (scope === StorageScope.Secure) {
+        flushSecureWrites();
       }
       return getStorageModule().getAllKeys(scope);
     });
@@ -519,6 +650,12 @@ export const storage = {
         return Array.from(memoryStore.keys()).filter((key) =>
           key.startsWith(prefix),
         );
+      }
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+      }
+      if (scope === StorageScope.Secure) {
+        flushSecureWrites();
       }
       return getStorageModule().getKeysByPrefix(prefix, scope);
     });
@@ -544,6 +681,12 @@ export const storage = {
         return result;
       }
 
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+      }
+      if (scope === StorageScope.Secure) {
+        flushSecureWrites();
+      }
       const values = getStorageModule().getBatch(keys, scope);
       keys.forEach((key, idx) => {
         const value = decodeNativeBatchValue(values[idx]);
@@ -564,6 +707,12 @@ export const storage = {
         });
         return result;
       }
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+      }
+      if (scope === StorageScope.Secure) {
+        flushSecureWrites();
+      }
       const keys = getStorageModule().getAllKeys(scope);
       if (keys.length === 0) return result;
       const values = getStorageModule().getBatch(keys, scope);
@@ -579,6 +728,12 @@ export const storage = {
       assertValidScope(scope);
       if (scope === StorageScope.Memory) {
         return memoryStore.size;
+      }
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+      }
+      if (scope === StorageScope.Secure) {
+        flushSecureWrites();
       }
       return getStorageModule().size(scope);
     });
@@ -597,6 +752,19 @@ export const storage = {
         getStorageModule().setSecureWritesAsync(enabled);
       },
     );
+  },
+  setDiskWritesAsync: (enabled: boolean) => {
+    measureOperation("storage:setDiskWritesAsync", StorageScope.Disk, () => {
+      diskWritesAsync = enabled;
+      if (!enabled) {
+        flushDiskWrites();
+      }
+    });
+  },
+  flushDiskWrites: () => {
+    measureOperation("storage:flushDiskWrites", StorageScope.Disk, () => {
+      flushDiskWrites();
+    });
   },
   flushSecureWrites: () => {
     measureOperation("storage:flushSecureWrites", StorageScope.Secure, () => {
@@ -631,6 +799,18 @@ export const storage = {
   resetMetrics: () => {
     metricsCounters.clear();
   },
+  getCapabilities: (): StorageCapabilities => ({
+    platform: "native",
+    backend: {
+      disk: "platform-preferences",
+      secure: "platform-secure-storage",
+    },
+    writeBuffering: {
+      disk: true,
+      secure: true,
+    },
+    errorClassification: true,
+  }),
   getString: (key: string, scope: StorageScope): string | undefined => {
     return measureOperation("storage:getString", scope, () => {
       return getRawValue(key, scope);
@@ -689,6 +869,20 @@ export function getWebSecureStorageBackend():
   return undefined;
 }
 
+export function setWebDiskStorageBackend(
+  _backend?: WebDiskStorageBackend,
+): void {
+  // Native platforms do not use web disk backends.
+}
+
+export function getWebDiskStorageBackend(): WebDiskStorageBackend | undefined {
+  return undefined;
+}
+
+export async function flushWebStorageBackends(): Promise<void> {
+  // Native platforms do not use web storage backends.
+}
+
 export interface StorageItemConfig<T> {
   key: string;
   scope: StorageScope;
@@ -700,6 +894,7 @@ export interface StorageItemConfig<T> {
   expiration?: ExpirationConfig;
   onExpired?: (key: string) => void;
   readCache?: boolean;
+  coalesceDiskWrites?: boolean;
   coalesceSecureWrites?: boolean;
   namespace?: string;
   biometric?: boolean;
@@ -784,6 +979,8 @@ export function createStorageItem<T = undefined>(
   const memoryExpiration =
     expiration && isMemory ? new Map<string, number>() : null;
   const readCache = !isMemory && config.readCache === true;
+  const coalesceDiskWrites =
+    config.scope === StorageScope.Disk && config.coalesceDiskWrites === true;
   const coalesceSecureWrites =
     config.scope === StorageScope.Secure &&
     config.coalesceSecureWrites === true &&
@@ -852,6 +1049,13 @@ export function createStorageItem<T = undefined>(
       return memoryStore.get(storageKey);
     }
 
+    if (nonMemoryScope === StorageScope.Disk) {
+      const pending = pendingDiskWrites.get(storageKey);
+      if (pending !== undefined) {
+        return pending.value;
+      }
+    }
+
     if (nonMemoryScope === StorageScope.Secure && !isBiometric) {
       const pending = pendingSecureWrites.get(storageKey);
       if (pending !== undefined) {
@@ -888,6 +1092,15 @@ export function createStorageItem<T = undefined>(
 
     cacheRawValue(nonMemoryScope!, storageKey, rawValue);
 
+    if (nonMemoryScope === StorageScope.Disk) {
+      if (coalesceDiskWrites || diskWritesAsync) {
+        scheduleDiskWrite(storageKey, rawValue);
+        return;
+      }
+
+      clearPendingDiskWrite(storageKey);
+    }
+
     if (coalesceSecureWrites) {
       scheduleSecureWrite(
         storageKey,
@@ -914,6 +1127,15 @@ export function createStorageItem<T = undefined>(
     }
 
     cacheRawValue(nonMemoryScope!, storageKey, undefined);
+
+    if (nonMemoryScope === StorageScope.Disk) {
+      if (coalesceDiskWrites || diskWritesAsync) {
+        scheduleDiskWrite(storageKey, undefined);
+        return;
+      }
+
+      clearPendingDiskWrite(storageKey);
+    }
 
     if (coalesceSecureWrites) {
       scheduleSecureWrite(
@@ -1125,6 +1347,18 @@ export function createStorageItem<T = undefined>(
     measureOperation("item:has", config.scope, () => {
       if (isMemory) return memoryStore.has(storageKey);
       if (isBiometric) return getStorageModule().hasSecureBiometric(storageKey);
+      if (nonMemoryScope === StorageScope.Disk) {
+        const pending = pendingDiskWrites.get(storageKey);
+        if (pending !== undefined) {
+          return pending.value !== undefined;
+        }
+      }
+      if (nonMemoryScope === StorageScope.Secure) {
+        const pending = pendingSecureWrites.get(storageKey);
+        if (pending !== undefined) {
+          return pending.value !== undefined;
+        }
+      }
       return getStorageModule().has(storageKey, config.scope);
     });
 
@@ -1224,6 +1458,14 @@ export function getBatch(
       const keyIndexes: number[] = [];
 
       items.forEach((item, index) => {
+        if (scope === StorageScope.Disk) {
+          const pending = pendingDiskWrites.get(item.key);
+          if (pending !== undefined) {
+            rawValues[index] = pending.value;
+            return;
+          }
+        }
+
         if (scope === StorageScope.Secure) {
           const pending = pendingSecureWrites.get(item.key);
           if (pending !== undefined) {
@@ -1353,6 +1595,8 @@ export function setBatch<T>(
         return;
       }
 
+      flushDiskWrites();
+
       const useRawBatchPath = items.every(({ item }) =>
         canUseRawBatchPath(asInternal(item)),
       );
@@ -1387,6 +1631,9 @@ export function removeBatch(
       }
 
       const keys = items.map((item) => item.key);
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+      }
       if (scope === StorageScope.Secure) {
         flushSecureWrites();
       }
@@ -1450,6 +1697,9 @@ export function runTransaction<T>(
 ): T {
   return measureOperation("transaction:run", scope, () => {
     assertValidScope(scope);
+    if (scope === StorageScope.Disk) {
+      flushDiskWrites();
+    }
     if (scope === StorageScope.Secure) {
       flushSecureWrites();
     }
@@ -1525,6 +1775,9 @@ export function runTransaction<T>(
           }
         });
 
+        if (scope === StorageScope.Disk) {
+          flushDiskWrites();
+        }
         if (scope === StorageScope.Secure) {
           flushSecureWrites();
         }
@@ -1555,16 +1808,7 @@ export type SecureAuthStorageConfig<K extends string = string> = Record<
 >;
 
 export function isKeychainLockedError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  const msg = err.message;
-  return (
-    msg.includes("errSecInteractionNotAllowed") ||
-    msg.includes("UserNotAuthenticatedException") ||
-    msg.includes("KeyStoreException") ||
-    msg.includes("KeyPermanentlyInvalidatedException") ||
-    msg.includes("InvalidKeyException") ||
-    msg.includes("android.security.keystore")
-  );
+  return isLockedStorageErrorCode(getStorageErrorCode(err));
 }
 
 export function createSecureAuthStorage<K extends string>(

--- a/packages/react-native-nitro-storage/src/index.web.ts
+++ b/packages/react-native-nitro-storage/src/index.web.ts
@@ -11,9 +11,32 @@ import {
   prefixKey,
   isNamespaced,
 } from "./internal";
+import {
+  createLocalStorageWebBackend,
+  type WebDiskStorageBackend,
+  type WebSecureStorageBackend,
+  type WebStorageBackend,
+  type WebStorageChangeEvent,
+} from "./web-storage-backend";
+import {
+  getStorageErrorCode,
+  isLockedStorageErrorCode,
+  type StorageCapabilities,
+  type StorageErrorCode,
+} from "./storage-runtime";
 
 export { StorageScope, AccessControl, BiometricLevel } from "./Storage.types";
 export { migrateFromMMKV } from "./migration";
+export {
+  getStorageErrorCode,
+  type StorageCapabilities,
+  type StorageErrorCode,
+} from "./storage-runtime";
+export type {
+  WebStorageBackend,
+  WebStorageChangeEvent,
+  WebStorageScope,
+} from "./web-storage-backend";
 
 export type Validator<T> = (value: unknown) => value is T;
 export type ExpirationConfig = {
@@ -37,14 +60,6 @@ export type StorageMetricSummary = {
   avgDurationMs: number;
   maxDurationMs: number;
 };
-export type WebSecureStorageBackend = {
-  getItem: (key: string) => string | null;
-  setItem: (key: string, value: string) => void;
-  removeItem: (key: string) => void;
-  clear: () => void;
-  getAllKeys: () => string[];
-};
-
 export type MigrationContext = {
   scope: StorageScope;
   getRaw: (key: string) => string | undefined;
@@ -91,18 +106,14 @@ function typedKeys<K extends string, V>(record: Record<K, V>): K[] {
   return Object.keys(record) as K[];
 }
 type NonMemoryScope = StorageScope.Disk | StorageScope.Secure;
+type PendingDiskWrite = {
+  key: string;
+  value: string | undefined;
+};
 type PendingSecureWrite = {
   key: string;
   value: string | undefined;
   accessControl?: AccessControl;
-};
-type BrowserStorageLike = {
-  setItem: (key: string, value: string) => void;
-  getItem: (key: string) => string | null;
-  removeItem: (key: string) => void;
-  clear: () => void;
-  key: (index: number) => string | null;
-  readonly length: number;
 };
 
 const registeredMigrations = new Map<number, Migration>();
@@ -112,6 +123,10 @@ const runMicrotask =
     : (task: () => void) => {
         Promise.resolve().then(task);
       };
+const now =
+  typeof performance !== "undefined" && typeof performance.now === "function"
+    ? () => performance.now()
+    : () => Date.now();
 
 export interface Storage {
   name: string;
@@ -161,14 +176,16 @@ const webScopeKeyIndex = new Map<NonMemoryScope, Set<string>>([
   [StorageScope.Secure, new Set()],
 ]);
 const hydratedWebScopeKeyIndex = new Set<NonMemoryScope>();
+const pendingDiskWrites = new Map<string, PendingDiskWrite>();
+let diskFlushScheduled = false;
+let diskWritesAsync = false;
 const pendingSecureWrites = new Map<string, PendingSecureWrite>();
 let secureFlushScheduled = false;
 let secureDefaultAccessControl: AccessControl = AccessControl.WhenUnlocked;
 const SECURE_WEB_PREFIX = "__secure_";
 const BIOMETRIC_WEB_PREFIX = "__bio_";
 let hasWarnedAboutWebBiometricFallback = false;
-let hasWebStorageEventSubscription = false;
-let webStorageSubscriberCount = 0;
+let hasWindowStorageEventSubscription = false;
 let metricsObserver: StorageMetricsObserver | undefined;
 const metricsCounters = new Map<
   string,
@@ -205,69 +222,86 @@ function measureOperation<T>(
   if (!metricsObserver) {
     return fn();
   }
-  const start = Date.now();
+  const start = now();
   try {
     return fn();
   } finally {
-    recordMetric(operation, scope, Date.now() - start, keysCount);
+    recordMetric(operation, scope, now() - start, keysCount);
   }
 }
 
-function createLocalStorageWebSecureBackend(): WebSecureStorageBackend {
-  return {
-    getItem: (key) => globalThis.localStorage?.getItem(key) ?? null,
-    setItem: (key, value) => globalThis.localStorage?.setItem(key, value),
-    removeItem: (key) => globalThis.localStorage?.removeItem(key),
-    clear: () => globalThis.localStorage?.clear(),
-    getAllKeys: () => {
-      const storage = globalThis.localStorage;
-      if (!storage) return [];
-      const keys: string[] = [];
-      for (let index = 0; index < storage.length; index += 1) {
-        const key = storage.key(index);
-        if (key) {
-          keys.push(key);
-        }
-      }
-      return keys;
-    },
-  };
+function createDefaultDiskBackend(): WebDiskStorageBackend {
+  return createLocalStorageWebBackend({
+    name: "localStorage:disk",
+    includeKey: (key) =>
+      !key.startsWith(SECURE_WEB_PREFIX) &&
+      !key.startsWith(BIOMETRIC_WEB_PREFIX),
+  });
 }
 
+function createDefaultSecureBackend(): WebSecureStorageBackend {
+  return createLocalStorageWebBackend({
+    name: "localStorage:secure",
+    includeKey: (key) =>
+      key.startsWith(SECURE_WEB_PREFIX) || key.startsWith(BIOMETRIC_WEB_PREFIX),
+  });
+}
+
+let webDiskStorageBackend: WebDiskStorageBackend | undefined =
+  createDefaultDiskBackend();
 let webSecureStorageBackend: WebSecureStorageBackend | undefined =
-  createLocalStorageWebSecureBackend();
+  createDefaultSecureBackend();
+const externalSyncUnsubscribers = new Map<NonMemoryScope, () => void>();
 
-let cachedSecureBrowserStorage: BrowserStorageLike | undefined;
-let cachedSecureBackendRef: WebSecureStorageBackend | undefined;
+function getBackendName(
+  scope: NonMemoryScope,
+  backend: WebStorageBackend | undefined,
+): string {
+  const scopeName = scope === StorageScope.Disk ? "disk" : "secure";
+  return backend?.name ?? `web:${scopeName}`;
+}
 
-function getBrowserStorage(scope: number): BrowserStorageLike | undefined {
-  if (scope === StorageScope.Disk) {
-    return globalThis.localStorage;
+function createWebStorageError(
+  scope: NonMemoryScope,
+  operation: string,
+  error: unknown,
+  backend: WebStorageBackend | undefined,
+): Error {
+  const backendName = getBackendName(scope, backend);
+  const message =
+    error instanceof Error ? error.message : String(error ?? "Unknown error");
+  return new Error(
+    `NitroStorage(web): ${operation} failed for ${backendName}: ${message}`,
+  );
+}
+
+function withWebBackendOperation<T>(
+  scope: NonMemoryScope,
+  operation: string,
+  fn: (backend: WebStorageBackend) => T,
+): T {
+  const backend =
+    scope === StorageScope.Disk
+      ? webDiskStorageBackend
+      : webSecureStorageBackend;
+  if (!backend) {
+    throw new Error(
+      `NitroStorage(web): ${operation} failed because no ${scope === StorageScope.Disk ? "disk" : "secure"} backend is configured.`,
+    );
   }
-  if (scope === StorageScope.Secure) {
-    if (!webSecureStorageBackend) {
-      return undefined;
-    }
-    if (
-      cachedSecureBackendRef === webSecureStorageBackend &&
-      cachedSecureBrowserStorage
-    ) {
-      return cachedSecureBrowserStorage;
-    }
-    cachedSecureBackendRef = webSecureStorageBackend;
-    cachedSecureBrowserStorage = {
-      setItem: (key, value) => webSecureStorageBackend!.setItem(key, value),
-      getItem: (key) => webSecureStorageBackend!.getItem(key) ?? null,
-      removeItem: (key) => webSecureStorageBackend!.removeItem(key),
-      clear: () => webSecureStorageBackend!.clear(),
-      key: (index) => webSecureStorageBackend!.getAllKeys()[index] ?? null,
-      get length() {
-        return webSecureStorageBackend!.getAllKeys().length;
-      },
-    };
-    return cachedSecureBrowserStorage;
+
+  try {
+    ensureExternalSyncSubscriptions();
+    return fn(backend);
+  } catch (error) {
+    throw createWebStorageError(scope, operation, error, backend);
   }
-  return undefined;
+}
+
+function getWebBackend(scope: NonMemoryScope): WebStorageBackend | undefined {
+  return scope === StorageScope.Disk
+    ? webDiskStorageBackend
+    : webSecureStorageBackend;
 }
 
 function toSecureStorageKey(key: string): string {
@@ -295,32 +329,22 @@ function hydrateWebScopeKeyIndex(scope: NonMemoryScope): void {
     return;
   }
 
-  const storage = getBrowserStorage(scope);
+  const backend = getWebBackend(scope);
   const keyIndex = getWebScopeKeyIndex(scope);
   keyIndex.clear();
-  if (storage) {
-    for (let index = 0; index < storage.length; index += 1) {
-      const key = storage.key(index);
-      if (!key) {
-        continue;
-      }
-      if (scope === StorageScope.Disk) {
-        if (
-          !key.startsWith(SECURE_WEB_PREFIX) &&
-          !key.startsWith(BIOMETRIC_WEB_PREFIX)
-        ) {
-          keyIndex.add(key);
-        }
-        continue;
-      }
+  const keys = backend?.getAllKeys() ?? [];
+  for (const key of keys) {
+    if (scope === StorageScope.Disk) {
+      keyIndex.add(key);
+      continue;
+    }
 
-      if (key.startsWith(SECURE_WEB_PREFIX)) {
-        keyIndex.add(fromSecureStorageKey(key));
-        continue;
-      }
-      if (key.startsWith(BIOMETRIC_WEB_PREFIX)) {
-        keyIndex.add(fromBiometricStorageKey(key));
-      }
+    if (key.startsWith(SECURE_WEB_PREFIX)) {
+      keyIndex.add(fromSecureStorageKey(key));
+      continue;
+    }
+    if (key.startsWith(BIOMETRIC_WEB_PREFIX)) {
+      keyIndex.add(fromBiometricStorageKey(key));
     }
   }
   hydratedWebScopeKeyIndex.add(scope);
@@ -331,37 +355,39 @@ function ensureWebScopeKeyIndex(scope: NonMemoryScope): Set<string> {
   return getWebScopeKeyIndex(scope);
 }
 
-function handleWebStorageEvent(event: StorageEvent): void {
-  const key = event.key;
+function applyExternalChangeEvent(
+  scope: NonMemoryScope,
+  key: string | null,
+  newValue: string | null,
+): void {
   if (key === null) {
-    clearScopeRawCache(StorageScope.Disk);
-    clearScopeRawCache(StorageScope.Secure);
-    ensureWebScopeKeyIndex(StorageScope.Disk).clear();
-    ensureWebScopeKeyIndex(StorageScope.Secure).clear();
-    notifyAllListeners(getScopedListeners(StorageScope.Disk));
-    notifyAllListeners(getScopedListeners(StorageScope.Secure));
+    clearScopeRawCache(scope);
+    ensureWebScopeKeyIndex(scope).clear();
+    notifyAllListeners(getScopedListeners(scope));
     return;
   }
 
-  if (key.startsWith(SECURE_WEB_PREFIX)) {
+  if (scope === StorageScope.Secure && key.startsWith(SECURE_WEB_PREFIX)) {
     const plainKey = fromSecureStorageKey(key);
-    if (event.newValue === null) {
+    if (newValue === null) {
       ensureWebScopeKeyIndex(StorageScope.Secure).delete(plainKey);
       cacheRawValue(StorageScope.Secure, plainKey, undefined);
     } else {
       ensureWebScopeKeyIndex(StorageScope.Secure).add(plainKey);
-      cacheRawValue(StorageScope.Secure, plainKey, event.newValue);
+      cacheRawValue(StorageScope.Secure, plainKey, newValue);
     }
     notifyKeyListeners(getScopedListeners(StorageScope.Secure), plainKey);
     return;
   }
 
-  if (key.startsWith(BIOMETRIC_WEB_PREFIX)) {
+  if (scope === StorageScope.Secure && key.startsWith(BIOMETRIC_WEB_PREFIX)) {
     const plainKey = fromBiometricStorageKey(key);
-    if (event.newValue === null) {
+    if (newValue === null) {
       if (
-        getBrowserStorage(StorageScope.Secure)?.getItem(
-          toSecureStorageKey(plainKey),
+        withWebBackendOperation(
+          StorageScope.Secure,
+          "external-sync:getItem",
+          (backend) => backend.getItem(toSecureStorageKey(plainKey)),
         ) === null
       ) {
         ensureWebScopeKeyIndex(StorageScope.Secure).delete(plainKey);
@@ -369,44 +395,74 @@ function handleWebStorageEvent(event: StorageEvent): void {
       cacheRawValue(StorageScope.Secure, plainKey, undefined);
     } else {
       ensureWebScopeKeyIndex(StorageScope.Secure).add(plainKey);
-      cacheRawValue(StorageScope.Secure, plainKey, event.newValue);
+      cacheRawValue(StorageScope.Secure, plainKey, newValue);
     }
     notifyKeyListeners(getScopedListeners(StorageScope.Secure), plainKey);
     return;
   }
 
-  if (event.newValue === null) {
-    ensureWebScopeKeyIndex(StorageScope.Disk).delete(key);
-    cacheRawValue(StorageScope.Disk, key, undefined);
+  if (newValue === null) {
+    ensureWebScopeKeyIndex(scope).delete(key);
+    cacheRawValue(scope, key, undefined);
   } else {
-    ensureWebScopeKeyIndex(StorageScope.Disk).add(key);
-    cacheRawValue(StorageScope.Disk, key, event.newValue);
+    ensureWebScopeKeyIndex(scope).add(key);
+    cacheRawValue(scope, key, newValue);
   }
-  notifyKeyListeners(getScopedListeners(StorageScope.Disk), key);
+  notifyKeyListeners(getScopedListeners(scope), key);
 }
 
-function ensureWebStorageEventSubscription(): void {
-  webStorageSubscriberCount += 1;
+function handleWebStorageEvent(event: StorageEvent): void {
+  const key = event.key;
+  if (key === null) {
+    applyExternalChangeEvent(StorageScope.Disk, null, null);
+    applyExternalChangeEvent(StorageScope.Secure, null, null);
+    return;
+  }
+
   if (
-    webStorageSubscriberCount === 1 &&
+    key.startsWith(SECURE_WEB_PREFIX) ||
+    key.startsWith(BIOMETRIC_WEB_PREFIX)
+  ) {
+    applyExternalChangeEvent(StorageScope.Secure, key, event.newValue);
+    return;
+  }
+
+  applyExternalChangeEvent(StorageScope.Disk, key, event.newValue);
+}
+
+function subscribeToBackendChanges(scope: NonMemoryScope): void {
+  if (externalSyncUnsubscribers.has(scope)) {
+    return;
+  }
+
+  const backend = getWebBackend(scope);
+  if (!backend?.subscribe) {
+    return;
+  }
+
+  const unsubscribe = backend.subscribe((event: WebStorageChangeEvent) => {
+    applyExternalChangeEvent(scope, event.key, event.newValue);
+  });
+  externalSyncUnsubscribers.set(scope, unsubscribe);
+}
+
+function resetBackendChangeSubscription(scope: NonMemoryScope): void {
+  externalSyncUnsubscribers.get(scope)?.();
+  externalSyncUnsubscribers.delete(scope);
+}
+
+function ensureExternalSyncSubscriptions(): void {
+  if (
+    !hasWindowStorageEventSubscription &&
     typeof window !== "undefined" &&
     typeof window.addEventListener === "function"
   ) {
     window.addEventListener("storage", handleWebStorageEvent);
-    hasWebStorageEventSubscription = true;
+    hasWindowStorageEventSubscription = true;
   }
-}
 
-function maybeCleanupWebStorageSubscription(): void {
-  webStorageSubscriberCount = Math.max(0, webStorageSubscriberCount - 1);
-  if (
-    webStorageSubscriberCount === 0 &&
-    hasWebStorageEventSubscription &&
-    typeof window !== "undefined"
-  ) {
-    window.removeEventListener("storage", handleWebStorageEvent);
-    hasWebStorageEventSubscription = false;
-  }
+  subscribeToBackendChanges(StorageScope.Disk);
+  subscribeToBackendChanges(StorageScope.Secure);
 }
 
 function getScopedListeners(scope: NonMemoryScope): KeyListenerRegistry {
@@ -487,12 +543,56 @@ function readPendingSecureWrite(key: string): string | undefined {
   return pendingSecureWrites.get(key)?.value;
 }
 
+function readPendingDiskWrite(key: string): string | undefined {
+  return pendingDiskWrites.get(key)?.value;
+}
+
+function hasPendingDiskWrite(key: string): boolean {
+  return pendingDiskWrites.has(key);
+}
+
 function hasPendingSecureWrite(key: string): boolean {
   return pendingSecureWrites.has(key);
 }
 
+function clearPendingDiskWrite(key: string): void {
+  pendingDiskWrites.delete(key);
+}
+
 function clearPendingSecureWrite(key: string): void {
   pendingSecureWrites.delete(key);
+}
+
+function flushDiskWrites(): void {
+  diskFlushScheduled = false;
+
+  if (pendingDiskWrites.size === 0) {
+    return;
+  }
+
+  const writes = Array.from(pendingDiskWrites.values());
+  pendingDiskWrites.clear();
+
+  const keysToSet: string[] = [];
+  const valuesToSet: string[] = [];
+  const keysToRemove: string[] = [];
+
+  writes.forEach(({ key, value }) => {
+    if (value === undefined) {
+      keysToRemove.push(key);
+      return;
+    }
+
+    keysToSet.push(key);
+    valuesToSet.push(value);
+  });
+
+  if (keysToSet.length > 0) {
+    WebStorage.setBatch(keysToSet, valuesToSet, StorageScope.Disk);
+  }
+  if (keysToRemove.length > 0) {
+    WebStorage.removeBatch(keysToRemove, StorageScope.Disk);
+  }
 }
 
 function flushSecureWrites(): void {
@@ -535,6 +635,15 @@ function flushSecureWrites(): void {
   }
 }
 
+function scheduleDiskWrite(key: string, value: string | undefined): void {
+  pendingDiskWrites.set(key, { key, value });
+  if (diskFlushScheduled) {
+    return;
+  }
+  diskFlushScheduled = true;
+  runMicrotask(flushDiskWrites);
+}
+
 function scheduleSecureWrite(
   key: string,
   value: string | undefined,
@@ -557,131 +666,142 @@ const WebStorage: Storage = {
   equals: (other) => other === WebStorage,
   dispose: () => {},
   set: (key: string, value: string, scope: number) => {
-    const storage = getBrowserStorage(scope);
-    if (!storage) {
+    if (scope !== StorageScope.Disk && scope !== StorageScope.Secure) {
       return;
     }
     const storageKey =
       scope === StorageScope.Secure ? toSecureStorageKey(key) : key;
-    storage.setItem(storageKey, value);
-    if (scope === StorageScope.Disk || scope === StorageScope.Secure) {
-      ensureWebScopeKeyIndex(scope).add(key);
-      notifyKeyListeners(getScopedListeners(scope), key);
-    }
+    withWebBackendOperation(scope, "set", (backend) => {
+      backend.setItem(storageKey, value);
+    });
+    ensureWebScopeKeyIndex(scope).add(key);
+    notifyKeyListeners(getScopedListeners(scope), key);
   },
   get: (key: string, scope: number) => {
-    const storage = getBrowserStorage(scope);
+    if (scope !== StorageScope.Disk && scope !== StorageScope.Secure) {
+      return undefined;
+    }
     const storageKey =
       scope === StorageScope.Secure ? toSecureStorageKey(key) : key;
-    return storage?.getItem(storageKey) ?? undefined;
+    const value = withWebBackendOperation(scope, "get", (backend) =>
+      backend.getItem(storageKey),
+    );
+    return value ?? undefined;
   },
   remove: (key: string, scope: number) => {
-    const storage = getBrowserStorage(scope);
-    if (!storage) {
+    if (scope !== StorageScope.Disk && scope !== StorageScope.Secure) {
       return;
     }
     if (scope === StorageScope.Secure) {
-      storage.removeItem(toSecureStorageKey(key));
-      storage.removeItem(toBiometricStorageKey(key));
+      withWebBackendOperation(scope, "remove", (backend) => {
+        if (backend.removeMany) {
+          backend.removeMany([
+            toSecureStorageKey(key),
+            toBiometricStorageKey(key),
+          ]);
+          return;
+        }
+        backend.removeItem(toSecureStorageKey(key));
+        backend.removeItem(toBiometricStorageKey(key));
+      });
     } else {
-      storage.removeItem(key);
+      withWebBackendOperation(scope, "remove", (backend) => {
+        backend.removeItem(key);
+      });
     }
-    if (scope === StorageScope.Disk || scope === StorageScope.Secure) {
-      ensureWebScopeKeyIndex(scope).delete(key);
-      notifyKeyListeners(getScopedListeners(scope), key);
-    }
+    ensureWebScopeKeyIndex(scope).delete(key);
+    notifyKeyListeners(getScopedListeners(scope), key);
   },
   clear: (scope: number) => {
-    const storage = getBrowserStorage(scope);
-    if (!storage) {
+    if (scope !== StorageScope.Disk && scope !== StorageScope.Secure) {
       return;
     }
-    if (scope === StorageScope.Secure) {
-      const keysToRemove: string[] = [];
-      for (let i = 0; i < storage.length; i++) {
-        const key = storage.key(i);
-        if (
-          key?.startsWith(SECURE_WEB_PREFIX) ||
-          key?.startsWith(BIOMETRIC_WEB_PREFIX)
-        ) {
-          keysToRemove.push(key);
-        }
-      }
-      keysToRemove.forEach((key) => storage.removeItem(key));
-    } else if (scope === StorageScope.Disk) {
-      const keysToRemove: string[] = [];
-      for (let i = 0; i < storage.length; i++) {
-        const key = storage.key(i);
-        if (
-          key &&
-          !key.startsWith(SECURE_WEB_PREFIX) &&
-          !key.startsWith(BIOMETRIC_WEB_PREFIX)
-        ) {
-          keysToRemove.push(key);
-        }
-      }
-      keysToRemove.forEach((key) => storage.removeItem(key));
-    } else {
-      storage.clear();
-    }
-    if (scope === StorageScope.Disk || scope === StorageScope.Secure) {
-      ensureWebScopeKeyIndex(scope).clear();
-      notifyAllListeners(getScopedListeners(scope));
-    }
+    withWebBackendOperation(scope, "clear", (backend) => {
+      backend.clear();
+    });
+    ensureWebScopeKeyIndex(scope).clear();
+    notifyAllListeners(getScopedListeners(scope));
   },
   setBatch: (keys: string[], values: string[], scope: number) => {
-    const storage = getBrowserStorage(scope);
-    if (!storage) {
+    if (scope !== StorageScope.Disk && scope !== StorageScope.Secure) {
       return;
     }
 
+    const entries: (readonly [string, string])[] = [];
     keys.forEach((key, index) => {
       const value = values[index];
       if (value === undefined) {
         return;
       }
-      const storageKey =
-        scope === StorageScope.Secure ? toSecureStorageKey(key) : key;
-      storage.setItem(storageKey, value);
+      entries.push([
+        scope === StorageScope.Secure ? toSecureStorageKey(key) : key,
+        value,
+      ]);
     });
-    if (scope === StorageScope.Disk || scope === StorageScope.Secure) {
-      const keyIndex = ensureWebScopeKeyIndex(scope);
-      keys.forEach((key) => keyIndex.add(key));
-      const listeners = getScopedListeners(scope);
-      keys.forEach((key) => notifyKeyListeners(listeners, key));
-    }
+    withWebBackendOperation(scope, "setBatch", (backend) => {
+      if (backend.setMany) {
+        backend.setMany(entries);
+        return;
+      }
+      entries.forEach(([storageKey, value]) => {
+        backend.setItem(storageKey, value);
+      });
+    });
+    const keyIndex = ensureWebScopeKeyIndex(scope);
+    keys.forEach((key) => keyIndex.add(key));
+    const listeners = getScopedListeners(scope);
+    keys.forEach((key) => notifyKeyListeners(listeners, key));
   },
   getBatch: (keys: string[], scope: number) => {
-    const storage = getBrowserStorage(scope);
-    return keys.map((key) => {
-      const storageKey =
-        scope === StorageScope.Secure ? toSecureStorageKey(key) : key;
-      return storage?.getItem(storageKey) ?? undefined;
+    if (scope !== StorageScope.Disk && scope !== StorageScope.Secure) {
+      return keys.map(() => undefined);
+    }
+    const storageKeys = keys.map((key) =>
+      scope === StorageScope.Secure ? toSecureStorageKey(key) : key,
+    );
+    const values = withWebBackendOperation(scope, "getBatch", (backend) => {
+      if (backend.getMany) {
+        return backend.getMany(storageKeys);
+      }
+      return storageKeys.map((storageKey) => backend.getItem(storageKey));
     });
+    return values.map((value) => value ?? undefined);
   },
   removeBatch: (keys: string[], scope: number) => {
-    const storage = getBrowserStorage(scope);
-    if (!storage) {
+    if (scope !== StorageScope.Disk && scope !== StorageScope.Secure) {
       return;
     }
 
     if (scope === StorageScope.Secure) {
-      keys.forEach((key) => {
-        storage.removeItem(toSecureStorageKey(key));
-        storage.removeItem(toBiometricStorageKey(key));
+      const storageKeys = keys.flatMap((key) => [
+        toSecureStorageKey(key),
+        toBiometricStorageKey(key),
+      ]);
+      withWebBackendOperation(scope, "removeBatch", (backend) => {
+        if (backend.removeMany) {
+          backend.removeMany(storageKeys);
+          return;
+        }
+        storageKeys.forEach((storageKey) => {
+          backend.removeItem(storageKey);
+        });
       });
     } else {
-      keys.forEach((key) => {
-        storage.removeItem(key);
+      withWebBackendOperation(scope, "removeBatch", (backend) => {
+        if (backend.removeMany) {
+          backend.removeMany(keys);
+          return;
+        }
+        keys.forEach((key) => {
+          backend.removeItem(key);
+        });
       });
     }
 
-    if (scope === StorageScope.Disk || scope === StorageScope.Secure) {
-      const keyIndex = ensureWebScopeKeyIndex(scope);
-      keys.forEach((key) => keyIndex.delete(key));
-      const listeners = getScopedListeners(scope);
-      keys.forEach((key) => notifyKeyListeners(listeners, key));
-    }
+    const keyIndex = ensureWebScopeKeyIndex(scope);
+    keys.forEach((key) => keyIndex.delete(key));
+    const listeners = getScopedListeners(scope);
+    keys.forEach((key) => notifyKeyListeners(listeners, key));
   },
   removeByPrefix: (prefix: string, scope: number) => {
     if (scope !== StorageScope.Disk && scope !== StorageScope.Secure) {
@@ -703,14 +823,24 @@ const WebStorage: Storage = {
     return () => {};
   },
   has: (key: string, scope: number) => {
-    const storage = getBrowserStorage(scope);
     if (scope === StorageScope.Secure) {
       return (
-        storage?.getItem(toSecureStorageKey(key)) !== null ||
-        storage?.getItem(toBiometricStorageKey(key)) !== null
+        withWebBackendOperation(scope, "has", (backend) =>
+          backend.getItem(toSecureStorageKey(key)),
+        ) !== null ||
+        withWebBackendOperation(scope, "has", (backend) =>
+          backend.getItem(toBiometricStorageKey(key)),
+        ) !== null
       );
     }
-    return storage?.getItem(key) !== null;
+    if (scope !== StorageScope.Disk) {
+      return false;
+    }
+    return (
+      withWebBackendOperation(scope, "has", (backend) =>
+        backend.getItem(key),
+      ) !== null
+    );
   },
   getAllKeys: (scope: number) => {
     if (scope !== StorageScope.Disk && scope !== StorageScope.Secure) {
@@ -753,51 +883,85 @@ const WebStorage: Storage = {
         "[NitroStorage] Biometric storage is not supported on web. Using localStorage.",
       );
     }
-    getBrowserStorage(StorageScope.Secure)?.setItem(
-      toBiometricStorageKey(key),
-      value,
+    withWebBackendOperation(
+      StorageScope.Secure,
+      "setSecureBiometric",
+      (backend) => backend.setItem(toBiometricStorageKey(key), value),
     );
     ensureWebScopeKeyIndex(StorageScope.Secure).add(key);
     notifyKeyListeners(getScopedListeners(StorageScope.Secure), key);
   },
   getSecureBiometric: (key: string) => {
-    return (
-      getBrowserStorage(StorageScope.Secure)?.getItem(
-        toBiometricStorageKey(key),
-      ) ?? undefined
+    const value = withWebBackendOperation(
+      StorageScope.Secure,
+      "getSecureBiometric",
+      (backend) => backend.getItem(toBiometricStorageKey(key)),
     );
+    return value ?? undefined;
   },
   deleteSecureBiometric: (key: string) => {
-    const storage = getBrowserStorage(StorageScope.Secure);
-    storage?.removeItem(toBiometricStorageKey(key));
-    if (storage?.getItem(toSecureStorageKey(key)) === null) {
+    withWebBackendOperation(
+      StorageScope.Secure,
+      "deleteSecureBiometric",
+      (backend) => backend.removeItem(toBiometricStorageKey(key)),
+    );
+    if (
+      withWebBackendOperation(
+        StorageScope.Secure,
+        "deleteSecureBiometric:getItem",
+        (backend) => backend.getItem(toSecureStorageKey(key)),
+      ) === null
+    ) {
       ensureWebScopeKeyIndex(StorageScope.Secure).delete(key);
     }
     notifyKeyListeners(getScopedListeners(StorageScope.Secure), key);
   },
   hasSecureBiometric: (key: string) => {
     return (
-      getBrowserStorage(StorageScope.Secure)?.getItem(
-        toBiometricStorageKey(key),
+      withWebBackendOperation(
+        StorageScope.Secure,
+        "hasSecureBiometric",
+        (backend) => backend.getItem(toBiometricStorageKey(key)),
       ) !== null
     );
   },
   clearSecureBiometric: () => {
-    const storage = getBrowserStorage(StorageScope.Secure);
-    if (!storage) return;
-    const keysToNotify: string[] = [];
-    const toRemove: string[] = [];
-    for (let i = 0; i < storage.length; i++) {
-      const k = storage.key(i);
-      if (k?.startsWith(BIOMETRIC_WEB_PREFIX)) {
-        toRemove.push(k);
-        keysToNotify.push(fromBiometricStorageKey(k));
-      }
+    const storageKeys = withWebBackendOperation(
+      StorageScope.Secure,
+      "clearSecureBiometric:getAllKeys",
+      (backend) => backend.getAllKeys(),
+    );
+    const keysToNotify = storageKeys
+      .filter((key) => key.startsWith(BIOMETRIC_WEB_PREFIX))
+      .map((key) => fromBiometricStorageKey(key));
+    if (keysToNotify.length === 0) {
+      return;
     }
-    toRemove.forEach((k) => storage.removeItem(k));
+    withWebBackendOperation(
+      StorageScope.Secure,
+      "clearSecureBiometric",
+      (backend) => {
+        const biometricKeys = keysToNotify.map((key) =>
+          toBiometricStorageKey(key),
+        );
+        if (backend.removeMany) {
+          backend.removeMany(biometricKeys);
+          return;
+        }
+        biometricKeys.forEach((storageKey) => {
+          backend.removeItem(storageKey);
+        });
+      },
+    );
     const keyIndex = ensureWebScopeKeyIndex(StorageScope.Secure);
     keysToNotify.forEach((key) => {
-      if (storage.getItem(toSecureStorageKey(key)) === null) {
+      if (
+        withWebBackendOperation(
+          StorageScope.Secure,
+          "clearSecureBiometric:getItem",
+          (backend) => backend.getItem(toSecureStorageKey(key)),
+        ) === null
+      ) {
         keyIndex.delete(key);
       }
     });
@@ -811,6 +975,10 @@ function getRawValue(key: string, scope: StorageScope): string | undefined {
   if (scope === StorageScope.Memory) {
     const value = memoryStore.get(key);
     return typeof value === "string" ? value : undefined;
+  }
+
+  if (scope === StorageScope.Disk && hasPendingDiskWrite(key)) {
+    return readPendingDiskWrite(key);
   }
 
   if (scope === StorageScope.Secure && hasPendingSecureWrite(key)) {
@@ -828,6 +996,17 @@ function setRawValue(key: string, value: string, scope: StorageScope): void {
     return;
   }
 
+  if (scope === StorageScope.Disk) {
+    cacheRawValue(scope, key, value);
+    if (diskWritesAsync) {
+      scheduleDiskWrite(key, value);
+      return;
+    }
+
+    flushDiskWrites();
+    clearPendingDiskWrite(key);
+  }
+
   if (scope === StorageScope.Secure) {
     flushSecureWrites();
     clearPendingSecureWrite(key);
@@ -843,6 +1022,17 @@ function removeRawValue(key: string, scope: StorageScope): void {
     memoryStore.delete(key);
     notifyKeyListeners(memoryListeners, key);
     return;
+  }
+
+  if (scope === StorageScope.Disk) {
+    cacheRawValue(scope, key, undefined);
+    if (diskWritesAsync) {
+      scheduleDiskWrite(key, undefined);
+      return;
+    }
+
+    flushDiskWrites();
+    clearPendingDiskWrite(key);
   }
 
   if (scope === StorageScope.Secure) {
@@ -875,6 +1065,11 @@ export const storage = {
         memoryStore.clear();
         notifyAllListeners(memoryListeners);
         return;
+      }
+
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+        pendingDiskWrites.clear();
       }
 
       if (scope === StorageScope.Secure) {
@@ -912,6 +1107,9 @@ export const storage = {
       }
 
       const keyPrefix = prefixKey(namespace, "");
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+      }
       if (scope === StorageScope.Secure) {
         flushSecureWrites();
       }
@@ -933,6 +1131,12 @@ export const storage = {
     return measureOperation("storage:has", scope, () => {
       assertValidScope(scope);
       if (scope === StorageScope.Memory) return memoryStore.has(key);
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+      }
+      if (scope === StorageScope.Secure) {
+        flushSecureWrites();
+      }
       return WebStorage.has(key, scope);
     });
   },
@@ -940,6 +1144,12 @@ export const storage = {
     return measureOperation("storage:getAllKeys", scope, () => {
       assertValidScope(scope);
       if (scope === StorageScope.Memory) return Array.from(memoryStore.keys());
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+      }
+      if (scope === StorageScope.Secure) {
+        flushSecureWrites();
+      }
       return WebStorage.getAllKeys(scope);
     });
   },
@@ -950,6 +1160,12 @@ export const storage = {
         return Array.from(memoryStore.keys()).filter((key) =>
           key.startsWith(prefix),
         );
+      }
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+      }
+      if (scope === StorageScope.Secure) {
+        flushSecureWrites();
       }
       return WebStorage.getKeysByPrefix(prefix, scope);
     });
@@ -975,6 +1191,12 @@ export const storage = {
         return result;
       }
 
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+      }
+      if (scope === StorageScope.Secure) {
+        flushSecureWrites();
+      }
       const values = WebStorage.getBatch(keys, scope);
       keys.forEach((key, index) => {
         const value = values[index];
@@ -995,6 +1217,12 @@ export const storage = {
         });
         return result;
       }
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+      }
+      if (scope === StorageScope.Secure) {
+        flushSecureWrites();
+      }
       const keys = WebStorage.getAllKeys(scope);
       if (keys.length === 0) return {};
       const values = WebStorage.getBatch(keys, scope);
@@ -1011,6 +1239,12 @@ export const storage = {
     return measureOperation("storage:size", scope, () => {
       assertValidScope(scope);
       if (scope === StorageScope.Memory) return memoryStore.size;
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+      }
+      if (scope === StorageScope.Secure) {
+        flushSecureWrites();
+      }
       return WebStorage.size(scope);
     });
   },
@@ -1020,6 +1254,19 @@ export const storage = {
   },
   setSecureWritesAsync: (_enabled: boolean) => {
     recordMetric("storage:setSecureWritesAsync", StorageScope.Secure, 0);
+  },
+  setDiskWritesAsync: (enabled: boolean) => {
+    measureOperation("storage:setDiskWritesAsync", StorageScope.Disk, () => {
+      diskWritesAsync = enabled;
+      if (!enabled) {
+        flushDiskWrites();
+      }
+    });
+  },
+  flushDiskWrites: () => {
+    measureOperation("storage:flushDiskWrites", StorageScope.Disk, () => {
+      flushDiskWrites();
+    });
   },
   flushSecureWrites: () => {
     measureOperation("storage:flushSecureWrites", StorageScope.Secure, () => {
@@ -1048,6 +1295,18 @@ export const storage = {
   resetMetrics: () => {
     metricsCounters.clear();
   },
+  getCapabilities: (): StorageCapabilities => ({
+    platform: "web",
+    backend: {
+      disk: getBackendName(StorageScope.Disk, webDiskStorageBackend),
+      secure: getBackendName(StorageScope.Secure, webSecureStorageBackend),
+    },
+    writeBuffering: {
+      disk: true,
+      secure: true,
+    },
+    errorClassification: true,
+  }),
   getString: (key: string, scope: StorageScope): string | undefined => {
     return measureOperation("storage:getString", scope, () => {
       return getRawValue(key, scope);
@@ -1085,6 +1344,9 @@ export const storage = {
           flushSecureWrites();
           WebStorage.setSecureAccessControl(secureDefaultAccessControl);
         }
+        if (scope === StorageScope.Disk) {
+          flushDiskWrites();
+        }
 
         WebStorage.setBatch(keys, values, scope);
         keys.forEach((key, index) => cacheRawValue(scope, key, values[index]));
@@ -1097,17 +1359,51 @@ export const storage = {
 export function setWebSecureStorageBackend(
   backend?: WebSecureStorageBackend,
 ): void {
-  webSecureStorageBackend = backend ?? createLocalStorageWebSecureBackend();
-  cachedSecureBrowserStorage = undefined;
-  cachedSecureBackendRef = undefined;
+  pendingSecureWrites.clear();
+  webSecureStorageBackend = backend ?? createDefaultSecureBackend();
+  resetBackendChangeSubscription(StorageScope.Secure);
   hydratedWebScopeKeyIndex.delete(StorageScope.Secure);
   clearScopeRawCache(StorageScope.Secure);
+  ensureExternalSyncSubscriptions();
 }
 
 export function getWebSecureStorageBackend():
   | WebSecureStorageBackend
   | undefined {
   return webSecureStorageBackend;
+}
+
+export function setWebDiskStorageBackend(
+  backend?: WebDiskStorageBackend,
+): void {
+  pendingDiskWrites.clear();
+  webDiskStorageBackend = backend ?? createDefaultDiskBackend();
+  resetBackendChangeSubscription(StorageScope.Disk);
+  hydratedWebScopeKeyIndex.delete(StorageScope.Disk);
+  clearScopeRawCache(StorageScope.Disk);
+  ensureExternalSyncSubscriptions();
+}
+
+export function getWebDiskStorageBackend(): WebDiskStorageBackend | undefined {
+  return webDiskStorageBackend;
+}
+
+export async function flushWebStorageBackends(): Promise<void> {
+  flushDiskWrites();
+  flushSecureWrites();
+
+  const flushes: Promise<void>[] = [];
+  const diskFlush = webDiskStorageBackend?.flush;
+  const secureFlush = webSecureStorageBackend?.flush;
+
+  if (diskFlush) {
+    flushes.push(diskFlush());
+  }
+  if (secureFlush) {
+    flushes.push(secureFlush());
+  }
+
+  await Promise.all(flushes);
 }
 
 export interface StorageItemConfig<T> {
@@ -1121,6 +1417,7 @@ export interface StorageItemConfig<T> {
   expiration?: ExpirationConfig;
   onExpired?: (key: string) => void;
   readCache?: boolean;
+  coalesceDiskWrites?: boolean;
   coalesceSecureWrites?: boolean;
   namespace?: string;
   biometric?: boolean;
@@ -1205,6 +1502,8 @@ export function createStorageItem<T = undefined>(
   const memoryExpiration =
     expiration && isMemory ? new Map<string, number>() : null;
   const readCache = !isMemory && config.readCache === true;
+  const coalesceDiskWrites =
+    config.scope === StorageScope.Disk && config.coalesceDiskWrites === true;
   const coalesceSecureWrites =
     config.scope === StorageScope.Secure &&
     config.coalesceSecureWrites === true &&
@@ -1250,7 +1549,7 @@ export function createStorageItem<T = undefined>(
       return;
     }
 
-    ensureWebStorageEventSubscription();
+    ensureExternalSyncSubscriptions();
     unsubscribe = addKeyListener(
       getScopedListeners(nonMemoryScope!),
       storageKey,
@@ -1271,6 +1570,13 @@ export function createStorageItem<T = undefined>(
         }
       }
       return memoryStore.get(storageKey);
+    }
+
+    if (nonMemoryScope === StorageScope.Disk) {
+      const pending = pendingDiskWrites.get(storageKey);
+      if (pending !== undefined) {
+        return pending.value;
+      }
     }
 
     if (nonMemoryScope === StorageScope.Secure && !isBiometric) {
@@ -1309,6 +1615,15 @@ export function createStorageItem<T = undefined>(
 
     cacheRawValue(nonMemoryScope!, storageKey, rawValue);
 
+    if (nonMemoryScope === StorageScope.Disk) {
+      if (coalesceDiskWrites || diskWritesAsync) {
+        scheduleDiskWrite(storageKey, rawValue);
+        return;
+      }
+
+      clearPendingDiskWrite(storageKey);
+    }
+
     if (coalesceSecureWrites) {
       scheduleSecureWrite(
         storageKey,
@@ -1332,6 +1647,15 @@ export function createStorageItem<T = undefined>(
     }
 
     cacheRawValue(nonMemoryScope!, storageKey, undefined);
+
+    if (nonMemoryScope === StorageScope.Disk) {
+      if (coalesceDiskWrites || diskWritesAsync) {
+        scheduleDiskWrite(storageKey, undefined);
+        return;
+      }
+
+      clearPendingDiskWrite(storageKey);
+    }
 
     if (coalesceSecureWrites) {
       scheduleSecureWrite(
@@ -1543,6 +1867,18 @@ export function createStorageItem<T = undefined>(
     measureOperation("item:has", config.scope, () => {
       if (isMemory) return memoryStore.has(storageKey);
       if (isBiometric) return WebStorage.hasSecureBiometric(storageKey);
+      if (nonMemoryScope === StorageScope.Disk) {
+        const pending = pendingDiskWrites.get(storageKey);
+        if (pending !== undefined) {
+          return pending.value !== undefined;
+        }
+      }
+      if (nonMemoryScope === StorageScope.Secure) {
+        const pending = pendingSecureWrites.get(storageKey);
+        if (pending !== undefined) {
+          return pending.value !== undefined;
+        }
+      }
       return WebStorage.has(storageKey, config.scope);
     });
 
@@ -1554,9 +1890,6 @@ export function createStorageItem<T = undefined>(
       if (listeners.size === 0 && unsubscribe) {
         unsubscribe();
         unsubscribe = null;
-        if (!isMemory) {
-          maybeCleanupWebStorageSubscription();
-        }
       }
     };
   };
@@ -1642,6 +1975,14 @@ export function getBatch(
       const keyIndexes: number[] = [];
 
       items.forEach((item, index) => {
+        if (scope === StorageScope.Disk) {
+          const pending = pendingDiskWrites.get(item.key);
+          if (pending !== undefined) {
+            rawValues[index] = pending.value;
+            return;
+          }
+        }
+
         if (scope === StorageScope.Secure) {
           const pending = pendingSecureWrites.get(item.key);
           if (pending !== undefined) {
@@ -1766,6 +2107,8 @@ export function setBatch<T>(
         return;
       }
 
+      flushDiskWrites();
+
       const useRawBatchPath = items.every(({ item }) =>
         canUseRawBatchPath(asInternal(item)),
       );
@@ -1799,6 +2142,9 @@ export function removeBatch(
       }
 
       const keys = items.map((item) => item.key);
+      if (scope === StorageScope.Disk) {
+        flushDiskWrites();
+      }
       if (scope === StorageScope.Secure) {
         flushSecureWrites();
       }
@@ -1862,6 +2208,9 @@ export function runTransaction<T>(
 ): T {
   return measureOperation("transaction:run", scope, () => {
     assertValidScope(scope);
+    if (scope === StorageScope.Disk) {
+      flushDiskWrites();
+    }
     if (scope === StorageScope.Secure) {
       flushSecureWrites();
     }
@@ -1937,6 +2286,9 @@ export function runTransaction<T>(
           }
         });
 
+        if (scope === StorageScope.Disk) {
+          flushDiskWrites();
+        }
         if (scope === StorageScope.Secure) {
           flushSecureWrites();
         }
@@ -2000,6 +2352,6 @@ export function createSecureAuthStorage<K extends string>(
   return result as Record<K, StorageItem<string>>;
 }
 
-export function isKeychainLockedError(_err: unknown): boolean {
-  return false;
+export function isKeychainLockedError(err: unknown): boolean {
+  return isLockedStorageErrorCode(getStorageErrorCode(err));
 }

--- a/packages/react-native-nitro-storage/src/indexeddb-backend.ts
+++ b/packages/react-native-nitro-storage/src/indexeddb-backend.ts
@@ -1,8 +1,16 @@
-import type { WebSecureStorageBackend } from "./index.web";
+import type {
+  WebSecureStorageBackend,
+  WebStorageChangeEvent,
+} from "./web-storage-backend";
 
 const DEFAULT_DB_NAME = "nitro-storage-secure";
 const DEFAULT_STORE_NAME = "keyvalue";
 const DB_VERSION = 1;
+
+export type IndexedDBBackendOptions = {
+  channelName?: string;
+  onError?: (error: Error) => void;
+};
 
 /**
  * Opens (or creates) an IndexedDB database and returns the underlying IDBDatabase.
@@ -59,9 +67,62 @@ function openDB(dbName: string, storeName: string): Promise<IDBDatabase> {
 export async function createIndexedDBBackend(
   dbName = DEFAULT_DB_NAME,
   storeName = DEFAULT_STORE_NAME,
+  options: IndexedDBBackendOptions = {},
 ): Promise<WebSecureStorageBackend> {
   const db = await openDB(dbName, storeName);
   const cache = new Map<string, string>();
+  const pendingWrites = new Set<Promise<void>>();
+  const subscribers = new Set<(event: WebStorageChangeEvent) => void>();
+  const sourceId = `nitro-storage-${Math.random().toString(36).slice(2)}`;
+  const channelName =
+    options.channelName ?? `nitro-storage:${dbName}:${storeName}`;
+  const channel =
+    typeof BroadcastChannel !== "undefined"
+      ? new BroadcastChannel(channelName)
+      : null;
+
+  function emitExternal(event: WebStorageChangeEvent): void {
+    subscribers.forEach((subscriber) => {
+      subscriber(event);
+    });
+  }
+
+  function handleAsyncError(error: unknown): void {
+    const normalized =
+      error instanceof Error
+        ? error
+        : new Error(String(error ?? "Unknown IndexedDB error"));
+    options.onError?.(normalized);
+  }
+
+  channel?.addEventListener("message", (event: MessageEvent) => {
+    const data = event.data as
+      | (WebStorageChangeEvent & { sourceId?: string })
+      | undefined;
+    if (!data || data.sourceId === sourceId) {
+      return;
+    }
+
+    if (data.key === null) {
+      cache.clear();
+    } else if (data.newValue === null) {
+      cache.delete(data.key);
+    } else {
+      cache.set(data.key, data.newValue);
+    }
+
+    emitExternal({
+      key: data.key,
+      newValue: data.newValue,
+    });
+  });
+
+  function publish(event: WebStorageChangeEvent): void {
+    channel?.postMessage({
+      ...event,
+      sourceId,
+    });
+  }
 
   // Hydrate the in-memory cache from IndexedDB.
   await new Promise<void>((resolve, reject) => {
@@ -85,14 +146,39 @@ export async function createIndexedDBBackend(
       reject(tx.error ?? new Error("Failed to load IndexedDB entries."));
   });
 
-  /** Fire-and-forget IndexedDB write. Errors are silently ignored to avoid
-   *  breaking the synchronous caller — the in-memory cache is always authoritative. */
+  function trackWrite(tx: IDBTransaction): void {
+    const pending = new Promise<void>((resolve) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => {
+        handleAsyncError(
+          tx.error ?? new Error("Failed to persist IndexedDB transaction."),
+        );
+        resolve();
+      };
+      tx.onabort = () => {
+        handleAsyncError(
+          tx.error ?? new Error("IndexedDB transaction was aborted."),
+        );
+        resolve();
+      };
+    });
+    pendingWrites.add(pending);
+    void pending.finally(() => {
+      pendingWrites.delete(pending);
+    });
+  }
+
+  /** Fire-and-forget IndexedDB write. The in-memory cache remains authoritative,
+   *  but async persistence failures are surfaced through `onError` and `flush()`. */
   function persistSet(key: string, value: string): void {
     try {
       const tx = db.transaction(storeName, "readwrite");
       tx.objectStore(storeName).put(value, key);
+      trackWrite(tx);
     } catch {
-      // Best-effort; cache is the source of truth.
+      handleAsyncError(
+        new Error(`Failed to queue IndexedDB write for "${key}".`),
+      );
     }
   }
 
@@ -100,8 +186,11 @@ export async function createIndexedDBBackend(
     try {
       const tx = db.transaction(storeName, "readwrite");
       tx.objectStore(storeName).delete(key);
+      trackWrite(tx);
     } catch {
-      // Best-effort.
+      handleAsyncError(
+        new Error(`Failed to queue IndexedDB delete for "${key}".`),
+      );
     }
   }
 
@@ -109,12 +198,14 @@ export async function createIndexedDBBackend(
     try {
       const tx = db.transaction(storeName, "readwrite");
       tx.objectStore(storeName).clear();
+      trackWrite(tx);
     } catch {
-      // Best-effort.
+      handleAsyncError(new Error("Failed to queue IndexedDB clear."));
     }
   }
 
   const backend: WebSecureStorageBackend = {
+    name: `indexeddb:${dbName}/${storeName}`,
     getItem(key: string): string | null {
       return cache.get(key) ?? null;
     },
@@ -122,20 +213,70 @@ export async function createIndexedDBBackend(
     setItem(key: string, value: string): void {
       cache.set(key, value);
       persistSet(key, value);
+      publish({ key, newValue: value });
     },
 
     removeItem(key: string): void {
       cache.delete(key);
       persistDelete(key);
+      publish({ key, newValue: null });
     },
 
     clear(): void {
       cache.clear();
       persistClear();
+      publish({ key: null, newValue: null });
     },
 
     getAllKeys(): string[] {
       return Array.from(cache.keys());
+    },
+    getMany(keys: string[]): (string | null)[] {
+      return keys.map((key) => cache.get(key) ?? null);
+    },
+    setMany(entries): void {
+      entries.forEach(([key, value]) => {
+        cache.set(key, value);
+      });
+      try {
+        const tx = db.transaction(storeName, "readwrite");
+        const store = tx.objectStore(storeName);
+        entries.forEach(([key, value]) => {
+          store.put(value, key);
+          publish({ key, newValue: value });
+        });
+        trackWrite(tx);
+      } catch {
+        handleAsyncError(new Error("Failed to queue IndexedDB batch write."));
+      }
+    },
+    removeMany(keys: string[]): void {
+      keys.forEach((key) => {
+        cache.delete(key);
+      });
+      try {
+        const tx = db.transaction(storeName, "readwrite");
+        const store = tx.objectStore(storeName);
+        keys.forEach((key) => {
+          store.delete(key);
+          publish({ key, newValue: null });
+        });
+        trackWrite(tx);
+      } catch {
+        handleAsyncError(new Error("Failed to queue IndexedDB batch delete."));
+      }
+    },
+    size(): number {
+      return cache.size;
+    },
+    subscribe(listener): () => void {
+      subscribers.add(listener);
+      return () => {
+        subscribers.delete(listener);
+      };
+    },
+    async flush(): Promise<void> {
+      await Promise.all(Array.from(pendingWrites));
     },
   };
 

--- a/packages/react-native-nitro-storage/src/storage-runtime.ts
+++ b/packages/react-native-nitro-storage/src/storage-runtime.ts
@@ -1,0 +1,94 @@
+export type StorageErrorCode =
+  | "keychain_locked"
+  | "authentication_required"
+  | "key_invalidated"
+  | "storage_corruption"
+  | "biometric_unavailable"
+  | "unsupported";
+
+export type StorageCapabilities = {
+  platform: "native" | "web";
+  backend: {
+    disk: string;
+    secure: string;
+  };
+  writeBuffering: {
+    disk: boolean;
+    secure: boolean;
+  };
+  errorClassification: boolean;
+};
+
+const STORAGE_ERROR_TAG_PATTERN = /\[nitro-error:([a-z_]+)\]/;
+
+export function getStorageErrorCode(
+  err: unknown,
+): StorageErrorCode | undefined {
+  if (!(err instanceof Error)) {
+    return undefined;
+  }
+
+  const message = err.message;
+  const taggedCode = message.match(STORAGE_ERROR_TAG_PATTERN)?.[1];
+
+  if (
+    taggedCode === "keychain_locked" ||
+    taggedCode === "authentication_required" ||
+    taggedCode === "key_invalidated" ||
+    taggedCode === "storage_corruption" ||
+    taggedCode === "biometric_unavailable" ||
+    taggedCode === "unsupported"
+  ) {
+    return taggedCode;
+  }
+
+  if (message.includes("errSecInteractionNotAllowed")) {
+    return "keychain_locked";
+  }
+
+  if (
+    message.includes("UserNotAuthenticatedException") ||
+    message.includes("KeyStoreException") ||
+    message.includes("android.security.keystore")
+  ) {
+    return "authentication_required";
+  }
+
+  if (
+    message.includes("KeyPermanentlyInvalidatedException") ||
+    message.includes("InvalidKeyException")
+  ) {
+    return "key_invalidated";
+  }
+
+  if (
+    message.includes("AEADBadTagException") ||
+    message.toLowerCase().includes("storage corruption") ||
+    message.toLowerCase().includes("corrupted storage")
+  ) {
+    return "storage_corruption";
+  }
+
+  if (
+    message.toLowerCase().includes("biometric storage unavailable") ||
+    message.toLowerCase().includes("biometric storage is not available")
+  ) {
+    return "biometric_unavailable";
+  }
+
+  if (message.toLowerCase().includes("unsupported")) {
+    return "unsupported";
+  }
+
+  return undefined;
+}
+
+export function isLockedStorageErrorCode(
+  code: StorageErrorCode | undefined,
+): boolean {
+  return (
+    code === "keychain_locked" ||
+    code === "authentication_required" ||
+    code === "key_invalidated"
+  );
+}

--- a/packages/react-native-nitro-storage/src/web-storage-backend.ts
+++ b/packages/react-native-nitro-storage/src/web-storage-backend.ts
@@ -1,0 +1,129 @@
+import { StorageScope } from "./Storage.types";
+
+export type WebStorageChangeEvent = {
+  key: string | null;
+  newValue: string | null;
+};
+
+export type WebStorageScope = StorageScope.Disk | StorageScope.Secure;
+
+export type WebStorageBackend = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+  clear: () => void;
+  getAllKeys: () => string[];
+  getMany?: (keys: string[]) => (string | null)[];
+  setMany?: (
+    entries: readonly (readonly [key: string, value: string])[],
+  ) => void;
+  removeMany?: (keys: string[]) => void;
+  size?: () => number;
+  subscribe?: (listener: (event: WebStorageChangeEvent) => void) => () => void;
+  flush?: () => Promise<void>;
+  name?: string;
+};
+
+export type WebDiskStorageBackend = WebStorageBackend;
+export type WebSecureStorageBackend = WebStorageBackend;
+
+type LocalStorageBackendOptions = {
+  includeKey?: (key: string) => boolean;
+  name?: string;
+  resolveStorage?: () => Storage | undefined;
+};
+
+function getResolvedStorage(
+  resolveStorage: (() => Storage | undefined) | undefined,
+): Storage | undefined {
+  if (resolveStorage) {
+    return resolveStorage();
+  }
+
+  if (typeof globalThis.localStorage === "undefined") {
+    return undefined;
+  }
+
+  return globalThis.localStorage;
+}
+
+export function createLocalStorageWebBackend(
+  options: LocalStorageBackendOptions = {},
+): WebStorageBackend {
+  const includeKey = options.includeKey;
+  const resolveStorage = options.resolveStorage;
+
+  const listKeys = (): string[] => {
+    const storage = getResolvedStorage(resolveStorage);
+    if (!storage) {
+      return [];
+    }
+
+    const keys: string[] = [];
+    for (let index = 0; index < storage.length; index += 1) {
+      const key = storage.key(index);
+      if (!key) {
+        continue;
+      }
+      if (includeKey && !includeKey(key)) {
+        continue;
+      }
+      keys.push(key);
+    }
+    return keys;
+  };
+
+  return {
+    name: options.name ?? "localStorage",
+    getItem(key: string): string | null {
+      return getResolvedStorage(resolveStorage)?.getItem(key) ?? null;
+    },
+    setItem(key: string, value: string): void {
+      getResolvedStorage(resolveStorage)?.setItem(key, value);
+    },
+    removeItem(key: string): void {
+      getResolvedStorage(resolveStorage)?.removeItem(key);
+    },
+    clear(): void {
+      const storage = getResolvedStorage(resolveStorage);
+      if (!storage) {
+        return;
+      }
+
+      listKeys().forEach((key) => {
+        storage.removeItem(key);
+      });
+    },
+    getAllKeys(): string[] {
+      return listKeys();
+    },
+    getMany(keys: string[]): (string | null)[] {
+      const storage = getResolvedStorage(resolveStorage);
+      if (!storage) {
+        return keys.map(() => null);
+      }
+      return keys.map((key) => storage.getItem(key));
+    },
+    setMany(entries): void {
+      const storage = getResolvedStorage(resolveStorage);
+      if (!storage) {
+        return;
+      }
+      entries.forEach(([key, value]) => {
+        storage.setItem(key, value);
+      });
+    },
+    removeMany(keys: string[]): void {
+      const storage = getResolvedStorage(resolveStorage);
+      if (!storage) {
+        return;
+      }
+      keys.forEach((key) => {
+        storage.removeItem(key);
+      });
+    },
+    size(): number {
+      return listKeys().length;
+    },
+  };
+}

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -19,6 +19,9 @@ const packageDir = path.join(
   "packages/react-native-nitro-storage"
 );
 const packageJsonPath = path.join(packageDir, "package.json");
+const packageFilter = "react-native-nitro-storage";
+const isCI =
+  process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
 
 function log(message, color = "green") {
   console.log(colors[color](message));
@@ -51,6 +54,20 @@ function execCommandWithOutput(command, options = {}) {
   }
 }
 
+function isInteractive() {
+  return process.stdin.isTTY && process.stdout.isTTY && !isCI;
+}
+
+function runCheck(label, command, options = {}) {
+  log(label, "cyan");
+  const ok = execCommand(command, options);
+  if (!ok) {
+    log(`✗ ${label.replace(/[^\w]+$/g, "")} failed`, "red");
+    process.exit(1);
+  }
+  console.log("");
+}
+
 function askQuestion(question) {
   const rl = readline.createInterface({
     input: process.stdin,
@@ -70,11 +87,14 @@ function getPackageVersion() {
   return packageJson.version;
 }
 
-function checkGitStatus() {
+function getGitStatus() {
   const status = execCommandWithOutput("git status --porcelain", {
     cwd: packageDir,
   });
-  return status === "" || status === null;
+  if (status === null || status === "") {
+    return [];
+  }
+  return status.split("\n").filter(Boolean);
 }
 
 function checkNpmAuth() {
@@ -82,10 +102,79 @@ function checkNpmAuth() {
   return whoami !== null && whoami !== "";
 }
 
+function formatGitStatus(statusLines) {
+  const preview = statusLines.slice(0, 10).join("\n");
+  const remainder =
+    statusLines.length > 10
+      ? `\n...and ${statusLines.length - 10} more changed path(s)`
+      : "";
+  return `${preview}${remainder}`;
+}
+
+async function confirmOrExit({
+  shouldSkip,
+  question,
+  onSkipMessage,
+  onDeclineMessage,
+}) {
+  if (shouldSkip) {
+    if (onSkipMessage) {
+      console.log(onSkipMessage);
+    }
+    return;
+  }
+
+  if (!isInteractive()) {
+    log(`${onDeclineMessage} Re-run with --yes if this is intentional.`, "red");
+    process.exit(1);
+  }
+
+  const answer = await askQuestion(question);
+  if (answer !== "y" && answer !== "yes") {
+    log(onDeclineMessage, "red");
+    process.exit(1);
+  }
+}
+
+function getPackSummary() {
+  const output = execCommandWithOutput("npm pack --dry-run --json", {
+    cwd: packageDir,
+  });
+  if (!output) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(output);
+    return Array.isArray(parsed) ? parsed[0] : parsed;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function formatBytes(value) {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return "unknown";
+  }
+
+  if (value < 1024) {
+    return `${value} B`;
+  }
+
+  if (value < 1024 * 1024) {
+    return `${(value / 1024).toFixed(1)} kB`;
+  }
+
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 async function main() {
   const args = process.argv.slice(2);
   const isDryRun = args.includes("--dry-run");
   const skipChecks = args.includes("--skip-checks");
+  const yes = args.includes("--yes");
+  const allowDirty = args.includes("--allow-dirty");
+  const skipPackPreview = args.includes("--skip-pack-preview");
   const tag =
     args.find((arg) => arg.startsWith("--tag="))?.split("=")[1] || "latest";
 
@@ -104,18 +193,23 @@ async function main() {
   if (!skipChecks) {
     log("Running pre-publish checks...", "cyan");
 
-    if (!checkGitStatus()) {
+    const gitStatus = getGitStatus();
+    if (gitStatus.length > 0) {
       log("⚠️  Warning: You have uncommitted changes", "yellow");
-      const answer = await askQuestion("Continue anyway? (y/n): ");
-      if (answer !== "y" && answer !== "yes") {
-        log("Publish cancelled", "red");
-        process.exit(1);
-      }
+      console.log(formatGitStatus(gitStatus));
+      await confirmOrExit({
+        shouldSkip: allowDirty || yes,
+        question: "Continue anyway? (y/n): ",
+        onSkipMessage: "  ✓ Dirty tree override enabled",
+        onDeclineMessage: "Publish cancelled",
+      });
     } else {
       console.log("  ✓ Git working directory is clean");
     }
 
-    if (!checkNpmAuth()) {
+    if (isDryRun) {
+      console.log("  ✓ Skipping npm auth check in dry-run mode");
+    } else if (!checkNpmAuth()) {
       log("✗ Not logged in to npm. Run: npm login", "red");
       process.exit(1);
     } else {
@@ -126,49 +220,89 @@ async function main() {
     console.log("");
   }
 
-  log("🧪 Running tests...", "cyan");
-  if (!execCommand("bun run test", { cwd: packageDir })) {
-    log("✗ Tests failed", "red");
-    process.exit(1);
-  }
-  console.log("");
+  runCheck(
+    "🧹 Running lint...",
+    `bun run lint -- --filter=${packageFilter}`,
+    { cwd: projectRoot }
+  );
+  runCheck(
+    "🎨 Running format check...",
+    `bun run format:check -- --filter=${packageFilter}`,
+    { cwd: projectRoot }
+  );
+  runCheck(
+    "📝 Running typecheck...",
+    `bun run typecheck -- --filter=${packageFilter}`,
+    { cwd: projectRoot }
+  );
+  runCheck(
+    "🔎 Running type-surface checks...",
+    `bun run test:types -- --filter=${packageFilter}`,
+    { cwd: projectRoot }
+  );
+  runCheck(
+    "🧪 Running unit tests...",
+    `bun run test -- --filter=${packageFilter}`,
+    { cwd: projectRoot }
+  );
+  runCheck(
+    "🧪 Running C++ tests...",
+    `bun run test:cpp -- --filter=${packageFilter}`,
+    { cwd: projectRoot }
+  );
+  runCheck(
+    "🏗️ Preparing package artifacts...",
+    [
+      "bun run clean",
+      "bun run codegen",
+      "bun run build",
+      "bun run test:types",
+      "bun run benchmark",
+      "bun run test:cpp",
+      "bun run check:pack",
+    ].join(" && "),
+    { cwd: packageDir }
+  );
 
-  log("🔨 Building package...", "cyan");
-  if (!execCommand("bun run build", { cwd: packageDir })) {
-    log("✗ Build failed", "red");
-    process.exit(1);
-  }
-  console.log("");
+  if (!skipPackPreview) {
+    log("📋 npm pack dry-run:", "cyan");
+    if (!execCommand("npm pack --dry-run", { cwd: packageDir })) {
+      log("✗ npm pack dry-run failed", "red");
+      process.exit(1);
+    }
 
-  log("📝 Running typecheck...", "cyan");
-  if (!execCommand("bun run typecheck", { cwd: packageDir })) {
-    log("✗ Typecheck failed", "red");
-    process.exit(1);
+    const packSummary = getPackSummary();
+    if (packSummary) {
+      const packageSize = packSummary.packageSize ?? packSummary.size;
+      console.log(
+        `  • tarball: ${packSummary.filename} (${formatBytes(packageSize)})`
+      );
+      console.log(
+        `  • unpacked: ${formatBytes(packSummary.unpackedSize)}, files: ${packSummary.files?.length ?? "?"}`
+      );
+    }
+    console.log("");
   }
-  console.log("");
-
-  log("📋 Package contents:", "cyan");
-  execCommand("npm pack --dry-run", { cwd: packageDir });
-  console.log("");
 
   if (!isDryRun) {
-    const answer = await askQuestion(
-      `Publish version ${version} to npm with tag "${tag}"? (y/n): `
-    );
-    if (answer !== "y" && answer !== "yes") {
-      log("Publish cancelled", "yellow");
-      process.exit(0);
-    }
+    await confirmOrExit({
+      shouldSkip: yes,
+      question: `Publish version ${version} to npm with tag "${tag}"? (y/n): `,
+      onSkipMessage: "  ✓ Publish confirmation skipped via --yes",
+      onDeclineMessage: "Publish cancelled",
+    });
     console.log("");
   }
 
   if (isDryRun) {
     log("🏃 Dry run complete! Package is ready to publish.", "green");
-    log(`Run without --dry-run to publish version ${version}`, "cyan");
+    log(
+      `Run without --dry-run${yes ? "" : " --yes"} to publish version ${version}`,
+      "cyan"
+    );
   } else {
     log("🚀 Publishing to npm...", "cyan");
-    const inCI = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
-    const publishCommand = `npm publish --tag ${tag} --access public${inCI ? " --provenance" : ""}`;
+    const publishCommand = `npm publish --tag ${tag} --access public${isCI ? " --provenance" : ""}`;
     if (!execCommand(publishCommand, { cwd: packageDir })) {
       log("✗ Publish failed", "red");
       process.exit(1);


### PR DESCRIPTION
## Summary
Prepare the `0.4.5` package release with the new web backend, disk buffering, and structured native error tagging work.

## Changes
- add pluggable web disk/secure backends, IndexedDB durability hooks, and cross-tab sync support
- add disk write buffering, runtime capability reporting, and stable storage error classification
- extend unit, C++, smoke, and example coverage for the new package surface
- tighten `scripts/publish.js` to match the real release gate and support non-interactive dry runs

## Why
The package surface grew beyond the previous release tooling and docs. This aligns the release with the shipped behavior and verification path.

## Notes
`expo-doctor` still reports pre-existing example app issues around asset MIME, Bun duplicate Expo installs, and SDK patch drift.

## Test
`bun run lint -- --filter=react-native-nitro-storage && bun run format:check -- --filter=react-native-nitro-storage && bun run typecheck -- --filter=react-native-nitro-storage && bun run test:types -- --filter=react-native-nitro-storage && bun run test -- --filter=react-native-nitro-storage && bun run test:cpp -- --filter=react-native-nitro-storage`
`bun example:ios && bun example:android`
`bun run publish-package -- --dry-run --yes --allow-dirty`
