### PR TITLE
Ship Watchman ignore for Android CMake cache

### DIFF
--- a/packages/react-native-nitro-storage/.watchmanconfig
+++ b/packages/react-native-nitro-storage/.watchmanconfig
@@ -1,0 +1,6 @@
+{
+  "ignore_dirs": [
+    "android/.cxx",
+    "android/build"
+  ]
+}

--- a/packages/react-native-nitro-storage/package.json
+++ b/packages/react-native-nitro-storage/package.json
@@ -36,6 +36,7 @@
     "*.podspec",
     "SECURITY.md",
     "app.plugin.js",
+    ".watchmanconfig",
     "!**/__tests__",
     "!**/__fixtures__",
     "!**/__mocks__",

--- a/packages/react-native-nitro-storage/scripts/check-pack-contents.js
+++ b/packages/react-native-nitro-storage/scripts/check-pack-contents.js
@@ -10,6 +10,7 @@ const requiredFiles = [
   "LICENSE",
   "SECURITY.md",
   "app.plugin.js",
+  ".watchmanconfig",
   "docs/api-reference.md",
   "docs/secure-storage.md",
   "docs/mmkv-migration.md",


### PR DESCRIPTION
# Summary
Ships a package-local Watchman config so consumers that watch the installed package do not scan transient Android CMake output.

# Changes
- Add `.watchmanconfig` for Android `.cxx` and build output
- Include the config in the published package files
- Keep the pack-content guard checking the config