### PR TITLE
Prepare 0.5.5 release

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,10 @@
+{
+  "ignore_dirs": [
+    "node_modules",
+    "node_modules/react-native-nitro-modules/android/.cxx",
+    "node_modules/.cache",
+    "android/.cxx",
+    "apps/example/android/.cxx",
+    "packages/react-native-nitro-storage/android/.cxx"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project are documented in this file.
 
 The format follows Keep a Changelog and the project adheres to SemVer.
 
+## 0.5.5 - 2026-05-14
+
+### Added
+
+- Add secure export guardrails: `storage.export(StorageScope.Secure)` now requires an explicit `{ includeSecureValues: true }` opt-in, with `storage.exportSecureUnsafe()` available for short-lived secure migration flows.
+- Add secure event observer redaction options so `storage.setEventObserver()` redacts Secure values by default and requires explicit opt-in for raw Secure event values.
+- Add Expo plugin Android backup rules that exclude Nitro Storage secure preference files from cloud backup and device transfer.
+- Add public web backend contract exports for `WebDiskStorageBackend` and `WebSecureStorageBackend` from the native and web entrypoints.
+
+### Changed
+
+- Close replaced web storage backends so IndexedDB-backed `BroadcastChannel` and database handles do not leak after backend swaps.
+- Update README and package docs for the current secure export, event observer, Expo backup, web backend, and TypeScript usage surface.
+- Update safe native/tooling dependencies, including Nitro `0.35.6`, AndroidX Security Crypto `1.1.0`, RN 0.83 Babel preset patch, Expo preset patch, SWC, Node types, and Turbo.
+- Extend the example app so web, Android, and iOS expose the same secure export guard, event observer redaction, and web backend override flows where each platform supports them.
+
+### Fixed
+
+- Avoid Metro private `metro-config/src/defaults/exclusionList` imports and exclude generated Android `.cxx` directories from Metro and Watchman scans.
+- Remove package-owned Android native log spam for expected unavailable biometric storage paths.
+- Modernize Android Gradle assignment syntax to avoid package-owned Gradle warnings.
+
 ## 0.5.4 - 2026-05-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm](https://img.shields.io/npm/v/react-native-nitro-storage)](https://www.npmjs.com/package/react-native-nitro-storage)
 [![MIT license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![React Native](https://img.shields.io/badge/react--native-%3E%3D0.75-61dafb)](https://reactnative.dev/)
-[![Nitro Modules](https://img.shields.io/badge/nitro--modules-%3E%3D0.35.5-black)](https://nitro.margelo.com/)
+[![Nitro Modules](https://img.shields.io/badge/nitro--modules-%3E%3D0.35.6-black)](https://nitro.margelo.com/)
 
 One storage layer for render-time state, persisted app state, and native secrets.
 
@@ -20,6 +20,7 @@ Use it when you want one storage API for React Native and web, with fast synchro
 - [Quick Start](#quick-start)
 - [Storage Scopes](#storage-scopes)
 - [Docs](#docs)
+- [TypeScript And IDE Safety](#typescript-and-ide-safety)
 - [Platform Support](#platform-support)
 - [Security Model](#security-model)
 - [Migration Paths](#migration-paths)
@@ -83,7 +84,8 @@ bunx expo install react-native-nitro-storage react-native-nitro-modules
         "react-native-nitro-storage",
         {
           "faceIDPermission": "Allow $(PRODUCT_NAME) to protect your secure data with Face ID",
-          "addBiometricPermissions": true
+          "addBiometricPermissions": true,
+          "configureAndroidBackup": true
         }
       ]
     ]
@@ -95,7 +97,7 @@ bunx expo install react-native-nitro-storage react-native-nitro-modules
 bunx expo prebuild
 ```
 
-The Expo plugin sets `NSFaceIDUsageDescription`, can opt into Android biometric permissions, and initializes the Android storage adapter in `MainApplication`.
+The Expo plugin sets `NSFaceIDUsageDescription`, can opt into Android biometric permissions, initializes the Android storage adapter in `MainApplication`, and writes Android backup rules that exclude Nitro Storage secure preference files from cloud backup and device transfer. Set `configureAndroidBackup: false` only when you maintain equivalent backup rules yourself.
 
 Bare React Native projects should install pods after adding the package:
 
@@ -199,7 +201,7 @@ const snapshot = storage.export(StorageScope.Disk);
 storage.import(snapshot, StorageScope.Disk);
 ```
 
-`storage.export(StorageScope.Secure)` returns raw secret values. Do not log Secure exports or include them in diagnostics, analytics, crash reports, or support bundles.
+`storage.export(StorageScope.Secure)` throws unless you pass `{ includeSecureValues: true }`. Prefer `storage.exportSecureUnsafe()` only for short-lived in-memory secure migration workflows. Do not log Secure exports or include them in diagnostics, analytics, crash reports, or support bundles.
 
 Subscribe to storage changes outside React:
 
@@ -284,6 +286,44 @@ The main building blocks are:
 
 See the full [API reference](docs/api-reference.md).
 
+## TypeScript And IDE Safety
+
+The public API is designed around typed storage items. Define the value type, default value, serializer, parser, and validator in one place so reads, writes, React hooks, batch APIs, migrations, and transactions all share the same contract.
+
+```ts
+type Preferences = {
+  theme: "system" | "light" | "dark";
+  compactMode: boolean;
+};
+
+const preferencesItem = createStorageItem<Preferences>({
+  key: "preferences",
+  scope: StorageScope.Disk,
+  defaultValue: { theme: "system", compactMode: false },
+  validate: (value): value is Preferences =>
+    typeof value === "object" &&
+    value !== null &&
+    ["system", "light", "dark"].includes(
+      (value as Partial<Preferences>).theme ?? "",
+    ) &&
+    typeof (value as Partial<Preferences>).compactMode === "boolean",
+});
+
+preferencesItem.set((current) => ({
+  ...current,
+  compactMode: !current.compactMode,
+}));
+```
+
+For web backend overrides, import the backend contracts instead of using loose object shapes:
+
+```ts
+import type {
+  WebDiskStorageBackend,
+  WebSecureStorageBackend,
+} from "react-native-nitro-storage";
+```
+
 ## Platform Support
 
 | Platform | Status    | Notes                                                                                                  |
@@ -297,7 +337,7 @@ Peer dependencies:
 
 - `react >=18.2.0`
 - `react-native >=0.75.0`
-- `react-native-nitro-modules >=0.35.5`
+- `react-native-nitro-modules >=0.35.6`
 
 ## Security Model
 

--- a/apps/example/app/index.tsx
+++ b/apps/example/app/index.tsx
@@ -1,19 +1,26 @@
 import { useRef, useState } from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { Platform, StyleSheet, Text, View } from "react-native";
 import {
   createSecureAuthStorage,
   createStorageItem,
+  flushWebStorageBackends,
   getBatch,
   getStorageErrorCode,
+  getWebDiskStorageBackend,
+  getWebSecureStorageBackend,
   migrateToLatest,
   registerMigration,
   removeBatch,
   runTransaction,
   setBatch,
+  setWebDiskStorageBackend,
+  setWebSecureStorageBackend,
   storage,
   StorageScope,
   useStorage,
   useStorageSelector,
+  type WebDiskStorageBackend,
+  type WebSecureStorageBackend,
 } from "react-native-nitro-storage";
 import {
   Button,
@@ -56,7 +63,6 @@ const namespacedItem = createStorageItem({
 });
 
 type AppConfig = { theme: "dark" | "light"; notifications: boolean };
-
 const configItem = createStorageItem<AppConfig>({
   key: "app-config",
   scope: StorageScope.Disk,
@@ -148,6 +154,7 @@ const bufferedDiskItem = createStorageItem({
 // ─── Component ────────────────────────────────────────────────────────────────
 
 const HOOK_LABELS = ["initial", "alpha", "beta", "gamma", "delta"];
+const isWebRuntime = Platform.OS === "web";
 
 let migVer = 30_000;
 
@@ -239,12 +246,67 @@ export default function HomeScreen() {
   const [diskBufferingEnabled, setDiskBufferingEnabled] = useState(false);
   const [diskBufferedPreview, setDiskBufferedPreview] = useState("(empty)");
   const [classifiedErrorCode, setClassifiedErrorCode] = useState("(none)");
+  const [secureExportStatus, setSecureExportStatus] = useState("(not run)");
+  const [secureObserverStatus, setSecureObserverStatus] = useState("(not run)");
+  const [webBackendStatus, setWebBackendStatus] = useState(
+    isWebRuntime ? "default localStorage backends" : "native platform backends",
+  );
   const capabilities = storage.getCapabilities();
   const securityCapabilities = storage.getSecurityCapabilities();
 
   const refreshSecureMetadata = () => {
     setSecureMetadata(storage.getSecureMetadata("secure-token"));
     setSecureMetadataCount(storage.getAllSecureMetadata().length);
+  };
+
+  const installWebBackends = () => {
+    if (!isWebRuntime) {
+      setWebBackendStatus("native platforms ignore web backend overrides");
+      return;
+    }
+
+    const diskStore = new Map<string, string>();
+    const secureStore = new Map<string, string>();
+    const createBackend = (
+      name: string,
+      store: Map<string, string>,
+    ): WebDiskStorageBackend | WebSecureStorageBackend => ({
+      name,
+      getItem: (key) => store.get(key) ?? null,
+      setItem: (key, value) => {
+        store.set(key, value);
+      },
+      removeItem: (key) => {
+        store.delete(key);
+      },
+      clear: () => {
+        store.clear();
+      },
+      getAllKeys: () => Array.from(store.keys()),
+      flush: async () => {},
+    });
+
+    const diskBackend = createBackend("example-web-disk", diskStore);
+    const secureBackend = createBackend("example-web-secure", secureStore);
+    setWebDiskStorageBackend(diskBackend);
+    setWebSecureStorageBackend(secureBackend);
+    storage.setString("web-backend-disk", "disk", StorageScope.Disk);
+    storage.setString("web-backend-secure", "secure", StorageScope.Secure);
+    void flushWebStorageBackends().then(() => {
+      const diskName = getWebDiskStorageBackend()?.name ?? "none";
+      const secureName = getWebSecureStorageBackend()?.name ?? "none";
+      setWebBackendStatus(`${diskName} / ${secureName}`);
+    });
+  };
+
+  const resetWebBackends = () => {
+    setWebDiskStorageBackend(undefined);
+    setWebSecureStorageBackend(undefined);
+    setWebBackendStatus(
+      isWebRuntime
+        ? "default localStorage backends"
+        : "native platform backends",
+    );
   };
 
   return (
@@ -289,6 +351,132 @@ export default function HomeScreen() {
             style={styles.flex1}
           />
         </View>
+      </Card>
+
+      <Card
+        title="Secure Export Guard"
+        subtitle="safe defaults for secret snapshots"
+        indicatorColor={Colors.secure}
+      >
+        <View style={styles.row}>
+          <Button
+            testID="secure-export-seed"
+            title="Seed Secret"
+            onPress={() => {
+              storage.setString(
+                "secure-export-demo",
+                "demo-secret",
+                StorageScope.Secure,
+              );
+              setSecureExportStatus("seeded secure-export-demo");
+              refreshSecureMetadata();
+            }}
+            style={styles.flex1}
+          />
+          <Button
+            testID="secure-export-guarded"
+            title="Guarded Export"
+            variant="secondary"
+            onPress={() => {
+              try {
+                storage.export(StorageScope.Secure);
+                setSecureExportStatus("unexpected export success");
+              } catch (error) {
+                setSecureExportStatus(
+                  getStorageErrorCode(error) ??
+                    "blocked by secure export guard",
+                );
+              }
+            }}
+            style={styles.flex1}
+          />
+        </View>
+        <View style={styles.row}>
+          <Button
+            testID="secure-export-explicit"
+            title="Explicit Export"
+            onPress={() => {
+              const exported = storage.export(StorageScope.Secure, {
+                includeSecureValues: true,
+              });
+              setSecureExportStatus(`${Object.keys(exported).length} keys`);
+            }}
+            style={styles.flex1}
+          />
+          <Button
+            testID="secure-export-unsafe"
+            title="Unsafe Helper"
+            variant="danger"
+            onPress={() => {
+              const exported = storage.exportSecureUnsafe();
+              setSecureExportStatus(`${Object.keys(exported).length} raw keys`);
+            }}
+            style={styles.flex1}
+          />
+        </View>
+        <StatusRow
+          testID="secure-export-status"
+          label="Result"
+          value={secureExportStatus}
+        />
+      </Card>
+
+      <Card
+        title="Secure Event Observer"
+        subtitle="redacted by default, raw by explicit opt-in"
+        indicatorColor={Colors.secure}
+      >
+        <View style={styles.row}>
+          <Button
+            testID="event-observer-redacted"
+            title="Redacted"
+            onPress={() => {
+              storage.setEventObserver((event) => {
+                if (event.type === "key") {
+                  setSecureObserverStatus(event.newValue ?? "(empty)");
+                }
+              });
+              storage.setString(
+                "secure-observer-demo",
+                "observer-secret",
+                StorageScope.Secure,
+              );
+              storage.setEventObserver(undefined);
+            }}
+            style={styles.flex1}
+          />
+          <Button
+            testID="event-observer-raw"
+            title="Raw Opt-In"
+            variant="secondary"
+            onPress={() => {
+              storage.setEventObserver(
+                (event) => {
+                  if (event.type === "key") {
+                    setSecureObserverStatus(
+                      event.newValue
+                        ? `raw value observed (${event.newValue.length} chars)`
+                        : "(empty)",
+                    );
+                  }
+                },
+                { redactSecureValues: false },
+              );
+              storage.setString(
+                "secure-observer-demo",
+                "observer-secret",
+                StorageScope.Secure,
+              );
+              storage.setEventObserver(undefined);
+            }}
+            style={styles.flex1}
+          />
+        </View>
+        <StatusRow
+          testID="event-observer-status"
+          label="Observed newValue"
+          value={secureObserverStatus}
+        />
       </Card>
 
       {/* 2. Disk Scope */}
@@ -1092,6 +1280,38 @@ export default function HomeScreen() {
           }}
           size="sm"
         />
+      </Card>
+
+      <Card
+        title="Web Backend Overrides"
+        subtitle="custom disk and secure adapters on web"
+        indicatorColor={Colors.disk}
+      >
+        <StatusRow
+          testID="web-backend-platform"
+          label="Platform"
+          value={Platform.OS}
+        />
+        <StatusRow
+          testID="web-backend-status"
+          label="Backend"
+          value={webBackendStatus}
+        />
+        <View style={styles.row}>
+          <Button
+            testID="web-backend-install"
+            title="Install"
+            onPress={installWebBackends}
+            style={styles.flex1}
+          />
+          <Button
+            testID="web-backend-reset"
+            title="Reset"
+            variant="secondary"
+            onPress={resetWebBackends}
+            style={styles.flex1}
+          />
+        </View>
       </Card>
 
       <Card

--- a/apps/example/metro.config.js
+++ b/apps/example/metro.config.js
@@ -24,6 +24,27 @@ config.resolver.nodeModulesPaths = [
   path.resolve(monorepoRoot, "node_modules"),
 ];
 
+const generatedNitroModulesCxx = new RegExp(
+  `${path
+    .resolve(
+      monorepoRoot,
+      "node_modules/react-native-nitro-modules/android/.cxx",
+    )
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[/\\\\].*`,
+);
+const bunOldNodeModules = new RegExp(
+  `${path
+    .resolve(monorepoRoot, "node_modules/.old-")
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[^/\\\\]+(?:[/\\\\].*)?$`,
+);
+config.resolver.blockList = Array.isArray(config.resolver.blockList)
+  ? [...config.resolver.blockList, generatedNitroModulesCxx, bunOldNodeModules]
+  : [
+      config.resolver.blockList,
+      generatedNitroModulesCxx,
+      bunOldNodeModules,
+    ].filter(Boolean);
+
 // Web platform: exclude native-only deps, use web entry for local package
 config.resolver.resolveRequest = (context, moduleName, platform) => {
   if (platform === "web") {
@@ -35,9 +56,9 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
         context,
         path.resolve(
           monorepoRoot,
-          "packages/react-native-nitro-storage/src/index.web.ts"
+          "packages/react-native-nitro-storage/src/index.web.ts",
         ),
-        platform
+        platform,
       );
     }
   }

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -27,7 +27,7 @@
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.6",
-    "react-native-nitro-modules": "0.35.5",
+    "react-native-nitro-modules": "0.35.6",
     "react-native-nitro-storage": "*",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",
@@ -36,6 +36,6 @@
   "devDependencies": {
     "@babel/core": "^7.29.0",
     "@types/react": "~19.2.14",
-    "babel-preset-expo": "~55.0.19"
+    "babel-preset-expo": "~55.0.21"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,22 +5,22 @@
     "": {
       "name": "react-native-nitro-storage-monorepo",
       "devDependencies": {
-        "@swc/core": "^1.15.30",
+        "@swc/core": "^1.15.33",
         "@swc/jest": "^0.2.39",
         "@types/jest": "^30.0.0",
-        "@types/node": "^25.6.0",
+        "@types/node": "^25.7.0",
         "eslint-config-expo-magic": "^2.4.0",
-        "jest": "^30.3.0",
-        "nitrogen": "0.35.5",
+        "jest": "30.3.0",
+        "nitrogen": "0.35.6",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "react-native": "0.83.6",
         "react-native-builder-bob": "^0.40.18",
-        "react-native-nitro-modules": "0.35.5",
+        "react-native-nitro-modules": "0.35.6",
         "react-test-renderer": "19.2.0",
         "rimraf": "^6.1.3",
         "ts-jest": "^29.4.9",
-        "turbo": "^2.9.6",
+        "turbo": "^2.9.12",
         "typescript": "^5.9.3",
       },
     },
@@ -43,7 +43,7 @@
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "react-native": "0.83.6",
-        "react-native-nitro-modules": "0.35.5",
+        "react-native-nitro-modules": "0.35.6",
         "react-native-nitro-storage": "*",
         "react-native-safe-area-context": "~5.6.2",
         "react-native-screens": "~4.23.0",
@@ -52,15 +52,15 @@
       "devDependencies": {
         "@babel/core": "^7.29.0",
         "@types/react": "~19.2.14",
-        "babel-preset-expo": "~55.0.19",
+        "babel-preset-expo": "~55.0.21",
       },
     },
     "packages/react-native-nitro-storage": {
       "name": "react-native-nitro-storage",
-      "version": "0.5.3",
+      "version": "0.5.5",
       "devDependencies": {
         "@expo/config-plugins": "^55.0.8",
-        "@react-native/babel-preset": "^0.83.6",
+        "@react-native/babel-preset": "^0.83.9",
         "@testing-library/react-hooks": "^8.0.1",
         "@testing-library/react-native": "^13.3.3",
         "@types/react": "~19.2.0",
@@ -68,7 +68,7 @@
       "peerDependencies": {
         "react": ">=18.2.0",
         "react-native": ">=0.75.0",
-        "react-native-nitro-modules": ">=0.35.5",
+        "react-native-nitro-modules": ">=0.35.6",
       },
     },
   },
@@ -77,7 +77,7 @@
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.6",
-    "react-native-nitro-modules": "0.35.5",
+    "react-native-nitro-modules": "0.35.6",
   },
   "packages": {
     "@ark/schema": ["@ark/schema@0.56.0", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA=="],
@@ -552,9 +552,9 @@
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 
-    "@react-native/babel-plugin-codegen": ["@react-native/babel-plugin-codegen@0.83.6", "", { "dependencies": { "@babel/traverse": "^7.25.3", "@react-native/codegen": "0.83.6" } }, "sha512-qfRXsHGeucT5c6mK+8Q7v4Ly3zmygfVmFlEtkiq7q07W1OTreld6nib4rJ/DBEeNiKBoBTuHjWliYGNuDjLFQA=="],
+    "@react-native/babel-plugin-codegen": ["@react-native/babel-plugin-codegen@0.83.9", "", { "dependencies": { "@babel/traverse": "^7.25.3", "@react-native/codegen": "0.83.9" } }, "sha512-JSsi7mhyjnSOJ3Lx8PFefFmnWDb1h1KySZS3VSZ21Pbi6T0MFd8mH/3u1onhihm3jsTe86l7IwS5++hRT9gs6A=="],
 
-    "@react-native/babel-preset": ["@react-native/babel-preset@0.83.6", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/plugin-proposal-export-default-from": "^7.24.7", "@babel/plugin-syntax-dynamic-import": "^7.8.3", "@babel/plugin-syntax-export-default-from": "^7.24.7", "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3", "@babel/plugin-syntax-optional-chaining": "^7.8.3", "@babel/plugin-transform-arrow-functions": "^7.24.7", "@babel/plugin-transform-async-generator-functions": "^7.25.4", "@babel/plugin-transform-async-to-generator": "^7.24.7", "@babel/plugin-transform-block-scoping": "^7.25.0", "@babel/plugin-transform-class-properties": "^7.25.4", "@babel/plugin-transform-classes": "^7.25.4", "@babel/plugin-transform-computed-properties": "^7.24.7", "@babel/plugin-transform-destructuring": "^7.24.8", "@babel/plugin-transform-flow-strip-types": "^7.25.2", "@babel/plugin-transform-for-of": "^7.24.7", "@babel/plugin-transform-function-name": "^7.25.1", "@babel/plugin-transform-literals": "^7.25.2", "@babel/plugin-transform-logical-assignment-operators": "^7.24.7", "@babel/plugin-transform-modules-commonjs": "^7.24.8", "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7", "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7", "@babel/plugin-transform-numeric-separator": "^7.24.7", "@babel/plugin-transform-object-rest-spread": "^7.24.7", "@babel/plugin-transform-optional-catch-binding": "^7.24.7", "@babel/plugin-transform-optional-chaining": "^7.24.8", "@babel/plugin-transform-parameters": "^7.24.7", "@babel/plugin-transform-private-methods": "^7.24.7", "@babel/plugin-transform-private-property-in-object": "^7.24.7", "@babel/plugin-transform-react-display-name": "^7.24.7", "@babel/plugin-transform-react-jsx": "^7.25.2", "@babel/plugin-transform-react-jsx-self": "^7.24.7", "@babel/plugin-transform-react-jsx-source": "^7.24.7", "@babel/plugin-transform-regenerator": "^7.24.7", "@babel/plugin-transform-runtime": "^7.24.7", "@babel/plugin-transform-shorthand-properties": "^7.24.7", "@babel/plugin-transform-spread": "^7.24.7", "@babel/plugin-transform-sticky-regex": "^7.24.7", "@babel/plugin-transform-typescript": "^7.25.2", "@babel/plugin-transform-unicode-regex": "^7.24.7", "@babel/template": "^7.25.0", "@react-native/babel-plugin-codegen": "0.83.6", "babel-plugin-syntax-hermes-parser": "0.32.0", "babel-plugin-transform-flow-enums": "^0.0.2", "react-refresh": "^0.14.0" } }, "sha512-4/fXFDUvGOObETZq4+SUFkafld6OGgQWut5cQiqVghlhCB5z/p2lVhPgEUr/aTxTzeS3AmN+ztC+GpYPQ7tsTw=="],
+    "@react-native/babel-preset": ["@react-native/babel-preset@0.83.9", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/plugin-proposal-export-default-from": "^7.24.7", "@babel/plugin-syntax-dynamic-import": "^7.8.3", "@babel/plugin-syntax-export-default-from": "^7.24.7", "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3", "@babel/plugin-syntax-optional-chaining": "^7.8.3", "@babel/plugin-transform-arrow-functions": "^7.24.7", "@babel/plugin-transform-async-generator-functions": "^7.25.4", "@babel/plugin-transform-async-to-generator": "^7.24.7", "@babel/plugin-transform-block-scoping": "^7.25.0", "@babel/plugin-transform-class-properties": "^7.25.4", "@babel/plugin-transform-classes": "^7.25.4", "@babel/plugin-transform-computed-properties": "^7.24.7", "@babel/plugin-transform-destructuring": "^7.24.8", "@babel/plugin-transform-flow-strip-types": "^7.25.2", "@babel/plugin-transform-for-of": "^7.24.7", "@babel/plugin-transform-function-name": "^7.25.1", "@babel/plugin-transform-literals": "^7.25.2", "@babel/plugin-transform-logical-assignment-operators": "^7.24.7", "@babel/plugin-transform-modules-commonjs": "^7.24.8", "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7", "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7", "@babel/plugin-transform-numeric-separator": "^7.24.7", "@babel/plugin-transform-object-rest-spread": "^7.24.7", "@babel/plugin-transform-optional-catch-binding": "^7.24.7", "@babel/plugin-transform-optional-chaining": "^7.24.8", "@babel/plugin-transform-parameters": "^7.24.7", "@babel/plugin-transform-private-methods": "^7.24.7", "@babel/plugin-transform-private-property-in-object": "^7.24.7", "@babel/plugin-transform-react-display-name": "^7.24.7", "@babel/plugin-transform-react-jsx": "^7.25.2", "@babel/plugin-transform-react-jsx-self": "^7.24.7", "@babel/plugin-transform-react-jsx-source": "^7.24.7", "@babel/plugin-transform-regenerator": "^7.24.7", "@babel/plugin-transform-runtime": "^7.24.7", "@babel/plugin-transform-shorthand-properties": "^7.24.7", "@babel/plugin-transform-spread": "^7.24.7", "@babel/plugin-transform-sticky-regex": "^7.24.7", "@babel/plugin-transform-typescript": "^7.25.2", "@babel/plugin-transform-unicode-regex": "^7.24.7", "@babel/template": "^7.25.0", "@react-native/babel-plugin-codegen": "0.83.9", "babel-plugin-syntax-hermes-parser": "0.32.0", "babel-plugin-transform-flow-enums": "^0.0.2", "react-refresh": "^0.14.0" } }, "sha512-/P7+jzOhq/Jt90vSreCL+r2gkApPc9nmM6sWgKTrn22E4Bo32LXtk/kARmpVBbkJI2h5pXvWeI6ODywbJw0slA=="],
 
     "@react-native/codegen": ["@react-native/codegen@0.83.6", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/parser": "^7.25.3", "glob": "^7.1.1", "hermes-parser": "0.32.0", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "yargs": "^17.6.2" } }, "sha512-doB/Pq6Cf6IjF3wlQXTIiZOnsX9X8mEEk+CdGfyuCwZjWrf7IB8KaZEXXckJmfUcIwvJ9u/a72ZoTTCIoxAc9A=="],
 
@@ -594,31 +594,31 @@
 
     "@sinonjs/fake-timers": ["@sinonjs/fake-timers@10.3.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.0" } }, "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA=="],
 
-    "@swc/core": ["@swc/core@1.15.30", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.26" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.30", "@swc/core-darwin-x64": "1.15.30", "@swc/core-linux-arm-gnueabihf": "1.15.30", "@swc/core-linux-arm64-gnu": "1.15.30", "@swc/core-linux-arm64-musl": "1.15.30", "@swc/core-linux-ppc64-gnu": "1.15.30", "@swc/core-linux-s390x-gnu": "1.15.30", "@swc/core-linux-x64-gnu": "1.15.30", "@swc/core-linux-x64-musl": "1.15.30", "@swc/core-win32-arm64-msvc": "1.15.30", "@swc/core-win32-ia32-msvc": "1.15.30", "@swc/core-win32-x64-msvc": "1.15.30" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-R8VQbQY1BZcbIF2p3gjlTCwAQzx1A194ugWfwld5y+WgVVWqVKm7eURGGOVbQVubgKWzidP2agomBbg96rZilQ=="],
+    "@swc/core": ["@swc/core@1.15.33", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.26" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.33", "@swc/core-darwin-x64": "1.15.33", "@swc/core-linux-arm-gnueabihf": "1.15.33", "@swc/core-linux-arm64-gnu": "1.15.33", "@swc/core-linux-arm64-musl": "1.15.33", "@swc/core-linux-ppc64-gnu": "1.15.33", "@swc/core-linux-s390x-gnu": "1.15.33", "@swc/core-linux-x64-gnu": "1.15.33", "@swc/core-linux-x64-musl": "1.15.33", "@swc/core-win32-arm64-msvc": "1.15.33", "@swc/core-win32-ia32-msvc": "1.15.33", "@swc/core-win32-x64-msvc": "1.15.33" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-jOlwnFV2xhuuZeAUILGFULeR6vDPfijEJ57evfocwznQldLU3w2cZ9bSDryY9ip+AsM3r1NJKzf47V2NXebkeQ=="],
 
-    "@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.15.30", "", { "os": "darwin", "cpu": "arm64" }, "sha512-VvpP+vq08HmGYewMWvrdsxh9s2lthz/808zXm8Yu5kaqeR8Yia2b0eYXleHQ3VAjoStUDk6LzTheBW9KXYQdMA=="],
+    "@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.15.33", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N+L0uXhuO7FIfzqwgxmzv0zIpV0qEp8wPX3QQs2p4atjMoywup2JTeDlXPw+z9pWJGCae3JjM+tZ6myclI+2gA=="],
 
-    "@swc/core-darwin-x64": ["@swc/core-darwin-x64@1.15.30", "", { "os": "darwin", "cpu": "x64" }, "sha512-WiJA0hiZI3nwQAO6mu5RqigtWGDtth4Hiq6rbZxAaQyhIcqKIg5IoMRc1Y071lrNJn29eEDMC86Rq58xgUxlDg=="],
+    "@swc/core-darwin-x64": ["@swc/core-darwin-x64@1.15.33", "", { "os": "darwin", "cpu": "x64" }, "sha512-/Il4QHSOhV4FekbsDtkrNmKbsX26oSysvgrRswa/RYOHXAkwXDbB4jaeKq6PsJLSPkzJ2KzQ061gtBnk0vNHfA=="],
 
-    "@swc/core-linux-arm-gnueabihf": ["@swc/core-linux-arm-gnueabihf@1.15.30", "", { "os": "linux", "cpu": "arm" }, "sha512-YANuFUo48kIT6plJgCD0keae9HFXfjxsbvsgevqc0hr/07X/p7sAWTFOGYEc2SXcASaK7UvuQqzlbW8pr7R79g=="],
+    "@swc/core-linux-arm-gnueabihf": ["@swc/core-linux-arm-gnueabihf@1.15.33", "", { "os": "linux", "cpu": "arm" }, "sha512-C64hBnBxq4viOPQ8hlx+2lJ23bzZBGnjw7ryALmS+0Q3zHmwO8lw1/DArLENw4Q18/0w5wdEO1k3m1wWNtKGqQ=="],
 
-    "@swc/core-linux-arm64-gnu": ["@swc/core-linux-arm64-gnu@1.15.30", "", { "os": "linux", "cpu": "arm64" }, "sha512-VndG8jaR4ugY6u+iVOT0Q+d2fZd7sLgjPgN8W/Le+3EbZKl+cRfFxV7Eoz4gfLqhmneZPdcIzf9T3LkgkmqNLg=="],
+    "@swc/core-linux-arm64-gnu": ["@swc/core-linux-arm64-gnu@1.15.33", "", { "os": "linux", "cpu": "arm64" }, "sha512-TRJfnJbX3jqpxRDRoieMzRiCBS5jOmXNb3iQXmcgjFEHKLnAgK1RZRU8Cq1MsPqO4jAJp/ld1G4O3fXuxv85uw=="],
 
-    "@swc/core-linux-arm64-musl": ["@swc/core-linux-arm64-musl@1.15.30", "", { "os": "linux", "cpu": "arm64" }, "sha512-1SYGs2l0Yyyi0pR/P/NKz/x0kqxkoiw+BXeJjLUdecSk/KasncWlJrc6hOvFSgKHOBrzgM5jwuluKtlT8dnrcA=="],
+    "@swc/core-linux-arm64-musl": ["@swc/core-linux-arm64-musl@1.15.33", "", { "os": "linux", "cpu": "arm64" }, "sha512-il7tYM+CpUNzieQbwAjFT1P8zqAhmGWNAGhQZBnxurXZ0aNn+5nqYFTEUKNZl7QibtT0uQXzTZrNGHCIj6Y1Og=="],
 
-    "@swc/core-linux-ppc64-gnu": ["@swc/core-linux-ppc64-gnu@1.15.30", "", { "os": "linux", "cpu": "ppc64" }, "sha512-TXREtiXeRhbfDFbmhnkIsXpKfzbfT73YkV2ZF6w0sfxgjC5zI2ZAbaCOq25qxvegofj2K93DtOpm9RLaBgqR2g=="],
+    "@swc/core-linux-ppc64-gnu": ["@swc/core-linux-ppc64-gnu@1.15.33", "", { "os": "linux", "cpu": "ppc64" }, "sha512-ZtNBwN0Z7CFj9Il0FcPaKdjgP7URyKu/3RfH46vq+0paOBqLj4NYldD6Qo//Duif/7IOtAraUfDOmp0PLAufog=="],
 
-    "@swc/core-linux-s390x-gnu": ["@swc/core-linux-s390x-gnu@1.15.30", "", { "os": "linux", "cpu": "s390x" }, "sha512-DCR2YYeyd6DQE4OuDhImouuNcjXEiEdnn1Y0DyGteugPEDvVuvYk8Xddi+4o2SgWH6jiW8/I+3emZvbep1NC+g=="],
+    "@swc/core-linux-s390x-gnu": ["@swc/core-linux-s390x-gnu@1.15.33", "", { "os": "linux", "cpu": "s390x" }, "sha512-De1IyajoOmhOYYjw/lx66bKlyDpHZTueqwpDrWgf5O7T6d1ODeJJO9/OqMBmrBQc5C+dNnlmIufHsp4QVCWufA=="],
 
-    "@swc/core-linux-x64-gnu": ["@swc/core-linux-x64-gnu@1.15.30", "", { "os": "linux", "cpu": "x64" }, "sha512-5Pizw3NgfOJ5BJOBK8TIRa59xFW2avESTOBDPTAYwZYa1JNDs+KMF9lUfjJiJLM5HiMs/wPheA9eiT0q9m2AoA=="],
+    "@swc/core-linux-x64-gnu": ["@swc/core-linux-x64-gnu@1.15.33", "", { "os": "linux", "cpu": "x64" }, "sha512-mGTH0YxmUN+x6vRN/I6NOk5X0ogNktkwPnJ94IMvR7QjhRDwL0O8RXEDhyUM0YtwWrryBOqaJQBX4zruxEPRGw=="],
 
-    "@swc/core-linux-x64-musl": ["@swc/core-linux-x64-musl@1.15.30", "", { "os": "linux", "cpu": "x64" }, "sha512-qyqydP/wyH8alcIP4a2hnGSjHLJjm9H7yDFup+CPy9oTahFgLLwnNcv5UHXqO2Qs3AIND+cls5f/Bb6hqpxdgA=="],
+    "@swc/core-linux-x64-musl": ["@swc/core-linux-x64-musl@1.15.33", "", { "os": "linux", "cpu": "x64" }, "sha512-hj628ZkSEJf6zMf5VMbYrG2O6QqyTIp2qwY6VlCjvIa9lAEZ5c2lfPblCLVGYubTeLJDxadLB/CxqQYOQABeEQ=="],
 
-    "@swc/core-win32-arm64-msvc": ["@swc/core-win32-arm64-msvc@1.15.30", "", { "os": "win32", "cpu": "arm64" }, "sha512-CaQENgDHVGOg1mSF5sQVgvfFHG9kjMor2rkLMLeLOkfZYNj13ppnJ9+lfaBZLZUMMbnlGQnavCJb8PVBUOso7Q=="],
+    "@swc/core-win32-arm64-msvc": ["@swc/core-win32-arm64-msvc@1.15.33", "", { "os": "win32", "cpu": "arm64" }, "sha512-GV2oohtN2/5+KSccl86VULu3aT+LrISC8uzgSq0FRnikpD+Zwc+sBlXmoKQ+Db6jI57ITUOIB8jRkdGMABC29g=="],
 
-    "@swc/core-win32-ia32-msvc": ["@swc/core-win32-ia32-msvc@1.15.30", "", { "os": "win32", "cpu": "ia32" }, "sha512-30VdLeGk6fugiUs/kUdJ/pAg7z/zpvVbR11RH60jZ0Z42WIeIniYx0rLEWN7h/pKJ3CopqsQ3RsogCAkRKiA2g=="],
+    "@swc/core-win32-ia32-msvc": ["@swc/core-win32-ia32-msvc@1.15.33", "", { "os": "win32", "cpu": "ia32" }, "sha512-gtyvzSNR8DHKfFEA2uqb8Ld1myqi6uEg2jyeUq3ikn5ytYs7H8RpZYC8mdy4NXr8hfcdJfCLXPlYaqqfBXpoEQ=="],
 
-    "@swc/core-win32-x64-msvc": ["@swc/core-win32-x64-msvc@1.15.30", "", { "os": "win32", "cpu": "x64" }, "sha512-4iObHPR+Q4oDY110EF5SF5eIaaVJNpMdG9C0q3Q92BsJ5y467uHz7sYQhP60WYlLFsLQ1el2YrIPUItUAQGOKg=="],
+    "@swc/core-win32-x64-msvc": ["@swc/core-win32-x64-msvc@1.15.33", "", { "os": "win32", "cpu": "x64" }, "sha512-d6fRqQSkJI+kmMEBWaDQ7TMl8+YjLYbwRUPZQ9DY0ORBJeTzOrG0twvfvlZ2xgw6jA0ScQKgfBm4vHLSLl5Hqg=="],
 
     "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
 
@@ -632,17 +632,17 @@
 
     "@ts-morph/common": ["@ts-morph/common@0.28.1", "", { "dependencies": { "minimatch": "^10.0.1", "path-browserify": "^1.0.1", "tinyglobby": "^0.2.14" } }, "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g=="],
 
-    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg=="],
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-eu3eFRmE9NjgZ0wPdRJ44l+LGSeIky+tz5ZQd8zQkw/Yqi+BM7wq+8nbabeoiVUcICi/IZweMOKl/MCmkrd1+g=="],
 
-    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw=="],
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RUkAE404z/J8NsyrUosMcBaXT6M4bRFxTQrmkDQBLQVXaC8Jl0e9bMvYDSX0GW7Ffm2m3j9y7RXgR1foeUAM9w=="],
 
-    "@turbo/linux-64": ["@turbo/linux-64@2.9.6", "", { "os": "linux", "cpu": "x64" }, "sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA=="],
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.12", "", { "os": "linux", "cpu": "x64" }, "sha512-InIUtH7cw/vqXNX1Gr7QgWfmw3ct08pV5CpfdEOR48z2u2rzdmpIuk00B/Q2xCb0PMWtKgiMQynfuphmEuUyTQ=="],
 
-    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g=="],
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-lC6nD//Xh67fmJM0LKaLsg74Wry0aYrgMklpiNgCbUaMdPIOqj0A00iri3NU7Lb7pZHx8ViisgpeDKlpSgFUCA=="],
 
-    "@turbo/windows-64": ["@turbo/windows-64@2.9.6", "", { "os": "win32", "cpu": "x64" }, "sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g=="],
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.12", "", { "os": "win32", "cpu": "x64" }, "sha512-conYri8VUl72JOdYnLDPYwzqbPcY5ECoHmo9FWoKznemhaAIilj4maHqs9Uar0aKfNoZIULniy+6iWaLtLO34A=="],
 
-    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A=="],
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-XoR4bsg62/L/esRVcmoMESEiNZ36+YmyjYGLpoqk8nwMgXzzVjNOgX0lRSz5w/U/ajLGv3nhMsS0Q2QOdvp2AQ=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
@@ -672,7 +672,7 @@
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
 
-    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+    "@types/node": ["@types/node@25.7.0", "", { "dependencies": { "undici-types": "~7.21.0" } }, "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -824,7 +824,7 @@
 
     "babel-preset-current-node-syntax": ["babel-preset-current-node-syntax@1.2.0", "", { "dependencies": { "@babel/plugin-syntax-async-generators": "^7.8.4", "@babel/plugin-syntax-bigint": "^7.8.3", "@babel/plugin-syntax-class-properties": "^7.12.13", "@babel/plugin-syntax-class-static-block": "^7.14.5", "@babel/plugin-syntax-import-attributes": "^7.24.7", "@babel/plugin-syntax-import-meta": "^7.10.4", "@babel/plugin-syntax-json-strings": "^7.8.3", "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4", "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3", "@babel/plugin-syntax-numeric-separator": "^7.10.4", "@babel/plugin-syntax-object-rest-spread": "^7.8.3", "@babel/plugin-syntax-optional-catch-binding": "^7.8.3", "@babel/plugin-syntax-optional-chaining": "^7.8.3", "@babel/plugin-syntax-private-property-in-object": "^7.14.5", "@babel/plugin-syntax-top-level-await": "^7.14.5" }, "peerDependencies": { "@babel/core": "^7.0.0 || ^8.0.0-0" } }, "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg=="],
 
-    "babel-preset-expo": ["babel-preset-expo@55.0.20", "", { "dependencies": { "@babel/generator": "^7.20.5", "@babel/helper-module-imports": "^7.25.9", "@babel/plugin-proposal-decorators": "^7.12.9", "@babel/plugin-proposal-export-default-from": "^7.24.7", "@babel/plugin-syntax-export-default-from": "^7.24.7", "@babel/plugin-transform-class-static-block": "^7.27.1", "@babel/plugin-transform-export-namespace-from": "^7.25.9", "@babel/plugin-transform-flow-strip-types": "^7.25.2", "@babel/plugin-transform-modules-commonjs": "^7.24.8", "@babel/plugin-transform-object-rest-spread": "^7.24.7", "@babel/plugin-transform-parameters": "^7.24.7", "@babel/plugin-transform-private-methods": "^7.24.7", "@babel/plugin-transform-private-property-in-object": "^7.24.7", "@babel/plugin-transform-runtime": "^7.24.7", "@babel/preset-react": "^7.22.15", "@babel/preset-typescript": "^7.23.0", "@react-native/babel-preset": "0.83.6", "babel-plugin-react-compiler": "^1.0.0", "babel-plugin-react-native-web": "~0.21.0", "babel-plugin-syntax-hermes-parser": "^0.32.0", "babel-plugin-transform-flow-enums": "^0.0.2", "debug": "^4.3.4", "resolve-from": "^5.0.0" }, "peerDependencies": { "@babel/runtime": "^7.20.0", "expo": "*", "expo-widgets": "^55.0.16", "react-refresh": ">=0.14.0 <1.0.0" }, "optionalPeers": ["@babel/runtime", "expo", "expo-widgets"] }, "sha512-wMSaNtpPrH7+QNBF7HOCfO6WgmdXO84JEdqMhFxWc1CvwcWTvWwgc4yQustW1q1kG5ZE/dHgHkmHPlvVY5apMQ=="],
+    "babel-preset-expo": ["babel-preset-expo@55.0.21", "", { "dependencies": { "@babel/generator": "^7.20.5", "@babel/helper-module-imports": "^7.25.9", "@babel/plugin-proposal-decorators": "^7.12.9", "@babel/plugin-proposal-export-default-from": "^7.24.7", "@babel/plugin-syntax-export-default-from": "^7.24.7", "@babel/plugin-transform-class-static-block": "^7.27.1", "@babel/plugin-transform-export-namespace-from": "^7.25.9", "@babel/plugin-transform-flow-strip-types": "^7.25.2", "@babel/plugin-transform-modules-commonjs": "^7.24.8", "@babel/plugin-transform-object-rest-spread": "^7.24.7", "@babel/plugin-transform-parameters": "^7.24.7", "@babel/plugin-transform-private-methods": "^7.24.7", "@babel/plugin-transform-private-property-in-object": "^7.24.7", "@babel/plugin-transform-runtime": "^7.24.7", "@babel/preset-react": "^7.22.15", "@babel/preset-typescript": "^7.23.0", "@react-native/babel-preset": "0.83.6", "babel-plugin-react-compiler": "^1.0.0", "babel-plugin-react-native-web": "~0.21.0", "babel-plugin-syntax-hermes-parser": "^0.32.0", "babel-plugin-transform-flow-enums": "^0.0.2", "debug": "^4.3.4", "resolve-from": "^5.0.0" }, "peerDependencies": { "@babel/runtime": "^7.20.0", "expo": "*", "expo-widgets": "^55.0.17", "react-refresh": ">=0.14.0 <1.0.0" }, "optionalPeers": ["@babel/runtime", "expo", "expo-widgets"] }, "sha512-anXoUZBcxydLdVs2L+r3bWKGUvZv2FtgOl8xRJ12i/YfKICBpwTGZWSTiEYTqBByZ6GkA3mE9+3TW97X2ocFTQ=="],
 
     "babel-preset-jest": ["babel-preset-jest@29.6.3", "", { "dependencies": { "babel-plugin-jest-hoist": "^29.6.3", "babel-preset-current-node-syntax": "^1.0.0" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA=="],
 
@@ -1580,7 +1580,7 @@
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
-    "nitrogen": ["nitrogen@0.35.5", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.35.5", "ts-morph": "^27.0.0", "yargs": "^18.0.0", "zod": "^4.0.5" }, "bin": { "nitrogen": "lib/index.js" } }, "sha512-Ofl4aTW2rd44+hBcUwLXu01ViHikn2SDI7zOYc+6NcKSpnhoj42k1FwyvRj1QZPDMUT64Bwlb0DYw7Hrfd3BfQ=="],
+    "nitrogen": ["nitrogen@0.35.6", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.35.6", "ts-morph": "^27.0.0", "yargs": "^18.0.0", "zod": "^4.0.5" }, "bin": { "nitrogen": "lib/index.js" } }, "sha512-fUoyqCEQugl49L/lp/v3LceZt8jwL/gqfLhWsxRPxr1pOTnBhyrcEJ2dAJvHl10h7JxaswP6YCnVZMZmjJavKg=="],
 
     "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
 
@@ -1738,7 +1738,7 @@
 
     "react-native-monorepo-config": ["react-native-monorepo-config@0.3.3", "", { "dependencies": { "escape-string-regexp": "^5.0.0", "fast-glob": "^3.3.3" } }, "sha512-d1kjHRVsbd/yVkFb5rYxWYiWVzCqJgUzcc499ejfc8jH6q6XYB4U+dNpX/HsxdXZLpzEhmKvgq0PsjRAIdAVeA=="],
 
-    "react-native-nitro-modules": ["react-native-nitro-modules@0.35.5", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-aa03UzC5dLg5qFfyBkVK+JGSwHTjmK7jUZzyRz11r1Yk9C/nJTFe59EeHPxxNNTagkiwQTM6p3sySgD/TDRC7Q=="],
+    "react-native-nitro-modules": ["react-native-nitro-modules@0.35.6", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-3Cb7s+O5tpZ6RdIiPOB/wi3IMfBxD6tl6VDF8gJ5zvM/BEGTWxwMMLjzmWmsYPKekdbYBznF6qp2d2SxixPy8g=="],
 
     "react-native-nitro-storage": ["react-native-nitro-storage@workspace:packages/react-native-nitro-storage"],
 
@@ -1956,7 +1956,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "turbo": ["turbo@2.9.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
+    "turbo": ["turbo@2.9.12", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.12", "@turbo/darwin-arm64": "2.9.12", "@turbo/linux-64": "2.9.12", "@turbo/linux-arm64": "2.9.12", "@turbo/windows-64": "2.9.12", "@turbo/windows-arm64": "2.9.12" }, "bin": { "turbo": "bin/turbo" } }, "sha512-lCPgus1NuTiBdaITWqzSH/Ff6HVL8HHGBtOXHg1dHRfcshN79XkygSdh0M6g8b0td91ILLG5MTkLOkp5UvyPJw=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
@@ -1984,7 +1984,7 @@
 
     "unc-path-regex": ["unc-path-regex@0.1.2", "", {}, "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg=="],
 
-    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+    "undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
 
     "unicode-canonical-property-names-ecmascript": ["unicode-canonical-property-names-ecmascript@2.0.1", "", {}, "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg=="],
 
@@ -2180,15 +2180,11 @@
 
     "@istanbuljs/load-nyc-config/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
-    "@jest/console/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
-
     "@jest/console/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@jest/console/jest-message-util": ["jest-message-util@30.3.0", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@jest/types": "30.3.0", "@types/stack-utils": "^2.0.3", "chalk": "^4.1.2", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3", "pretty-format": "30.3.0", "slash": "^3.0.0", "stack-utils": "^2.0.6" } }, "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw=="],
 
     "@jest/console/jest-util": ["jest-util@30.3.0", "", { "dependencies": { "@jest/types": "30.3.0", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3" } }, "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg=="],
-
-    "@jest/core/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "@jest/core/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -2224,8 +2220,6 @@
 
     "@jest/pattern/@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
 
-    "@jest/reporters/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
-
     "@jest/reporters/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@jest/reporters/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
@@ -2252,6 +2246,8 @@
 
     "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
+    "@react-native/babel-plugin-codegen/@react-native/codegen": ["@react-native/codegen@0.83.9", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/parser": "^7.25.3", "glob": "^7.1.1", "hermes-parser": "0.32.0", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "yargs": "^17.6.2" } }, "sha512-fUliGYOD1D/hS4pZMK+YyGb01DxQQNUTjL+i2iL6elt2AncXoYMWNxLT/AMT38jImxI4FbKyH4JO+mL2+t5yuA=="],
+
     "@react-native/codegen/hermes-parser": ["hermes-parser@0.32.0", "", { "dependencies": { "hermes-estree": "0.32.0" } }, "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw=="],
 
     "@react-native/codegen/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
@@ -2277,6 +2273,8 @@
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "babel-plugin-syntax-hermes-parser/hermes-parser": ["hermes-parser@0.32.0", "", { "dependencies": { "hermes-estree": "0.32.0" } }, "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw=="],
+
+    "babel-preset-expo/@react-native/babel-preset": ["@react-native/babel-preset@0.83.6", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/plugin-proposal-export-default-from": "^7.24.7", "@babel/plugin-syntax-dynamic-import": "^7.8.3", "@babel/plugin-syntax-export-default-from": "^7.24.7", "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3", "@babel/plugin-syntax-optional-chaining": "^7.8.3", "@babel/plugin-transform-arrow-functions": "^7.24.7", "@babel/plugin-transform-async-generator-functions": "^7.25.4", "@babel/plugin-transform-async-to-generator": "^7.24.7", "@babel/plugin-transform-block-scoping": "^7.25.0", "@babel/plugin-transform-class-properties": "^7.25.4", "@babel/plugin-transform-classes": "^7.25.4", "@babel/plugin-transform-computed-properties": "^7.24.7", "@babel/plugin-transform-destructuring": "^7.24.8", "@babel/plugin-transform-flow-strip-types": "^7.25.2", "@babel/plugin-transform-for-of": "^7.24.7", "@babel/plugin-transform-function-name": "^7.25.1", "@babel/plugin-transform-literals": "^7.25.2", "@babel/plugin-transform-logical-assignment-operators": "^7.24.7", "@babel/plugin-transform-modules-commonjs": "^7.24.8", "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7", "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7", "@babel/plugin-transform-numeric-separator": "^7.24.7", "@babel/plugin-transform-object-rest-spread": "^7.24.7", "@babel/plugin-transform-optional-catch-binding": "^7.24.7", "@babel/plugin-transform-optional-chaining": "^7.24.8", "@babel/plugin-transform-parameters": "^7.24.7", "@babel/plugin-transform-private-methods": "^7.24.7", "@babel/plugin-transform-private-property-in-object": "^7.24.7", "@babel/plugin-transform-react-display-name": "^7.24.7", "@babel/plugin-transform-react-jsx": "^7.25.2", "@babel/plugin-transform-react-jsx-self": "^7.24.7", "@babel/plugin-transform-react-jsx-source": "^7.24.7", "@babel/plugin-transform-regenerator": "^7.24.7", "@babel/plugin-transform-runtime": "^7.24.7", "@babel/plugin-transform-shorthand-properties": "^7.24.7", "@babel/plugin-transform-spread": "^7.24.7", "@babel/plugin-transform-sticky-regex": "^7.24.7", "@babel/plugin-transform-typescript": "^7.25.2", "@babel/plugin-transform-unicode-regex": "^7.24.7", "@babel/template": "^7.25.0", "@react-native/babel-plugin-codegen": "0.83.6", "babel-plugin-syntax-hermes-parser": "0.32.0", "babel-plugin-transform-flow-enums": "^0.0.2", "react-refresh": "^0.14.0" } }, "sha512-4/fXFDUvGOObETZq4+SUFkafld6OGgQWut5cQiqVghlhCB5z/p2lVhPgEUr/aTxTzeS3AmN+ztC+GpYPQ7tsTw=="],
 
     "better-opn/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
@@ -2336,8 +2334,6 @@
 
     "execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
-    "expo/babel-preset-expo": ["babel-preset-expo@55.0.21", "", { "dependencies": { "@babel/generator": "^7.20.5", "@babel/helper-module-imports": "^7.25.9", "@babel/plugin-proposal-decorators": "^7.12.9", "@babel/plugin-proposal-export-default-from": "^7.24.7", "@babel/plugin-syntax-export-default-from": "^7.24.7", "@babel/plugin-transform-class-static-block": "^7.27.1", "@babel/plugin-transform-export-namespace-from": "^7.25.9", "@babel/plugin-transform-flow-strip-types": "^7.25.2", "@babel/plugin-transform-modules-commonjs": "^7.24.8", "@babel/plugin-transform-object-rest-spread": "^7.24.7", "@babel/plugin-transform-parameters": "^7.24.7", "@babel/plugin-transform-private-methods": "^7.24.7", "@babel/plugin-transform-private-property-in-object": "^7.24.7", "@babel/plugin-transform-runtime": "^7.24.7", "@babel/preset-react": "^7.22.15", "@babel/preset-typescript": "^7.23.0", "@react-native/babel-preset": "0.83.6", "babel-plugin-react-compiler": "^1.0.0", "babel-plugin-react-native-web": "~0.21.0", "babel-plugin-syntax-hermes-parser": "^0.32.0", "babel-plugin-transform-flow-enums": "^0.0.2", "debug": "^4.3.4", "resolve-from": "^5.0.0" }, "peerDependencies": { "@babel/runtime": "^7.20.0", "expo": "*", "expo-widgets": "^55.0.17", "react-refresh": ">=0.14.0 <1.0.0" }, "optionalPeers": ["@babel/runtime", "expo", "expo-widgets"] }, "sha512-anXoUZBcxydLdVs2L+r3bWKGUvZv2FtgOl8xRJ12i/YfKICBpwTGZWSTiEYTqBByZ6GkA3mE9+3TW97X2ocFTQ=="],
-
     "expo/pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
 
     "expo-modules-autolinking/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -2373,8 +2369,6 @@
     "jest-changed-files/jest-util": ["jest-util@30.3.0", "", { "dependencies": { "@jest/types": "30.3.0", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3" } }, "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg=="],
 
     "jest-circus/@jest/environment": ["@jest/environment@30.3.0", "", { "dependencies": { "@jest/fake-timers": "30.3.0", "@jest/types": "30.3.0", "@types/node": "*", "jest-mock": "30.3.0" } }, "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw=="],
-
-    "jest-circus/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "jest-circus/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -2444,8 +2438,6 @@
 
     "jest-runner/@jest/environment": ["@jest/environment@30.3.0", "", { "dependencies": { "@jest/fake-timers": "30.3.0", "@jest/types": "30.3.0", "@types/node": "*", "jest-mock": "30.3.0" } }, "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw=="],
 
-    "jest-runner/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
-
     "jest-runner/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-runner/jest-environment-node": ["jest-environment-node@30.3.0", "", { "dependencies": { "@jest/environment": "30.3.0", "@jest/fake-timers": "30.3.0", "@jest/types": "30.3.0", "@types/node": "*", "jest-mock": "30.3.0", "jest-util": "30.3.0", "jest-validate": "30.3.0" } }, "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ=="],
@@ -2459,8 +2451,6 @@
     "jest-runtime/@jest/environment": ["@jest/environment@30.3.0", "", { "dependencies": { "@jest/fake-timers": "30.3.0", "@jest/types": "30.3.0", "@types/node": "*", "jest-mock": "30.3.0" } }, "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw=="],
 
     "jest-runtime/@jest/fake-timers": ["@jest/fake-timers@30.3.0", "", { "dependencies": { "@jest/types": "30.3.0", "@sinonjs/fake-timers": "^15.0.0", "@types/node": "*", "jest-message-util": "30.3.0", "jest-mock": "30.3.0", "jest-util": "30.3.0" } }, "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ=="],
-
-    "jest-runtime/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "jest-runtime/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -2497,8 +2487,6 @@
     "jest-validate/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-validate/pretty-format": ["pretty-format@30.3.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ=="],
-
-    "jest-watcher/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "jest-watcher/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -2712,15 +2700,15 @@
 
     "@istanbuljs/load-nyc-config/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
-    "@jest/console/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
     "@jest/console/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@jest/console/jest-message-util/pretty-format": ["pretty-format@30.3.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ=="],
 
-    "@jest/core/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "@jest/console/jest-util/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "@jest/core/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "@jest/core/jest-util/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "@jest/core/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
@@ -2764,21 +2752,17 @@
 
     "@jest/globals/@jest/environment/@jest/fake-timers": ["@jest/fake-timers@30.3.0", "", { "dependencies": { "@jest/types": "30.3.0", "@sinonjs/fake-timers": "^15.0.0", "@types/node": "*", "jest-message-util": "30.3.0", "jest-mock": "30.3.0", "jest-util": "30.3.0" } }, "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ=="],
 
-    "@jest/globals/@jest/environment/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
-
-    "@jest/globals/jest-mock/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
-
     "@jest/globals/jest-mock/jest-util": ["jest-util@30.3.0", "", { "dependencies": { "@jest/types": "30.3.0", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3" } }, "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg=="],
 
     "@jest/pattern/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@jest/reporters/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@jest/reporters/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@jest/reporters/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "@jest/reporters/jest-message-util/pretty-format": ["pretty-format@30.3.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ=="],
+
+    "@jest/reporters/jest-util/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "@jest/snapshot-utils/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -2789,6 +2773,10 @@
     "@jest/types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@jest/types/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "@react-native/babel-plugin-codegen/@react-native/codegen/hermes-parser": ["hermes-parser@0.32.0", "", { "dependencies": { "hermes-estree": "0.32.0" } }, "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw=="],
+
+    "@react-native/babel-plugin-codegen/@react-native/codegen/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "@react-native/codegen/hermes-parser/hermes-estree": ["hermes-estree@0.32.0", "", {}, "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ=="],
 
@@ -2815,6 +2803,8 @@
     "babel-plugin-istanbul/istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "babel-plugin-syntax-hermes-parser/hermes-parser/hermes-estree": ["hermes-estree@0.32.0", "", {}, "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ=="],
+
+    "babel-preset-expo/@react-native/babel-preset/@react-native/babel-plugin-codegen": ["@react-native/babel-plugin-codegen@0.83.6", "", { "dependencies": { "@babel/traverse": "^7.25.3", "@react-native/codegen": "0.83.6" } }, "sha512-qfRXsHGeucT5c6mK+8Q7v4Ly3zmygfVmFlEtkiq7q07W1OTreld6nib4rJ/DBEeNiKBoBTuHjWliYGNuDjLFQA=="],
 
     "chrome-launcher/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -2958,11 +2948,11 @@
 
     "jest-circus/@jest/environment/jest-mock": ["jest-mock@30.3.0", "", { "dependencies": { "@jest/types": "30.3.0", "@types/node": "*", "jest-util": "30.3.0" } }, "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog=="],
 
-    "jest-circus/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
     "jest-circus/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "jest-circus/jest-matcher-utils/jest-diff": ["jest-diff@30.3.0", "", { "dependencies": { "@jest/diff-sequences": "30.3.0", "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "pretty-format": "30.3.0" } }, "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ=="],
+
+    "jest-circus/jest-util/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "jest-circus/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
@@ -2985,8 +2975,6 @@
     "jest-config/jest-environment-node/@jest/environment": ["@jest/environment@30.3.0", "", { "dependencies": { "@jest/fake-timers": "30.3.0", "@jest/types": "30.3.0", "@types/node": "*", "jest-mock": "30.3.0" } }, "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw=="],
 
     "jest-config/jest-environment-node/@jest/fake-timers": ["@jest/fake-timers@30.3.0", "", { "dependencies": { "@jest/types": "30.3.0", "@sinonjs/fake-timers": "^15.0.0", "@types/node": "*", "jest-message-util": "30.3.0", "jest-mock": "30.3.0", "jest-util": "30.3.0" } }, "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ=="],
-
-    "jest-config/jest-environment-node/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "jest-config/jest-environment-node/jest-mock": ["jest-mock@30.3.0", "", { "dependencies": { "@jest/types": "30.3.0", "@types/node": "*", "jest-util": "30.3.0" } }, "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog=="],
 
@@ -3038,8 +3026,6 @@
 
     "jest-runner/@jest/environment/jest-mock": ["jest-mock@30.3.0", "", { "dependencies": { "@jest/types": "30.3.0", "@types/node": "*", "jest-util": "30.3.0" } }, "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog=="],
 
-    "jest-runner/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
     "jest-runner/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "jest-runner/jest-environment-node/@jest/fake-timers": ["@jest/fake-timers@30.3.0", "", { "dependencies": { "@jest/types": "30.3.0", "@sinonjs/fake-timers": "^15.0.0", "@types/node": "*", "jest-message-util": "30.3.0", "jest-mock": "30.3.0", "jest-util": "30.3.0" } }, "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ=="],
@@ -3048,17 +3034,19 @@
 
     "jest-runner/jest-message-util/pretty-format": ["pretty-format@30.3.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ=="],
 
+    "jest-runner/jest-util/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+
     "jest-runner/source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
-    "jest-runtime/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.3.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-m2xozxSfCIxjDdvbhIWazlP2i2aha/iUmbl94alpsIbd3iLTfeXgfBVbwyWogB6l++istyGZqamgA/EcqYf+Bg=="],
-
-    "jest-runtime/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "jest-runtime/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.4.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA=="],
 
     "jest-runtime/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "jest-runtime/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "jest-runtime/jest-message-util/pretty-format": ["pretty-format@30.3.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ=="],
+
+    "jest-runtime/jest-util/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "jest-snapshot/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -3078,9 +3066,9 @@
 
     "jest-validate/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
-    "jest-watcher/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
     "jest-watcher/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "jest-watcher/jest-util/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "jest-worker/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -3228,6 +3216,10 @@
 
     "@jest/console/jest-message-util/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
+    "@jest/console/jest-util/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "@jest/core/jest-util/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
     "@jest/create-cache-key-function/@jest/types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@jest/create-cache-key-function/@jest/types/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -3252,8 +3244,6 @@
 
     "@jest/expect/expect/jest-message-util/pretty-format": ["pretty-format@30.3.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ=="],
 
-    "@jest/expect/expect/jest-mock/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
-
     "@jest/expect/expect/jest-util/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "@jest/expect/expect/jest-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -3270,15 +3260,13 @@
 
     "@jest/fake-timers/jest-util/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "@jest/globals/@jest/environment/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.3.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-m2xozxSfCIxjDdvbhIWazlP2i2aha/iUmbl94alpsIbd3iLTfeXgfBVbwyWogB6l++istyGZqamgA/EcqYf+Bg=="],
+    "@jest/globals/@jest/environment/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.4.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA=="],
 
     "@jest/globals/@jest/environment/@jest/fake-timers/jest-message-util": ["jest-message-util@30.3.0", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@jest/types": "30.3.0", "@types/stack-utils": "^2.0.3", "chalk": "^4.1.2", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3", "pretty-format": "30.3.0", "slash": "^3.0.0", "stack-utils": "^2.0.6" } }, "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw=="],
 
     "@jest/globals/@jest/environment/@jest/fake-timers/jest-util": ["jest-util@30.3.0", "", { "dependencies": { "@jest/types": "30.3.0", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3" } }, "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg=="],
 
-    "@jest/globals/@jest/environment/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@jest/globals/jest-mock/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "@jest/globals/jest-mock/jest-util/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "@jest/globals/jest-mock/jest-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -3286,7 +3274,15 @@
 
     "@jest/reporters/jest-message-util/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
+    "@jest/reporters/jest-util/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
     "@jest/transform/jest-util/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "@react-native/babel-plugin-codegen/@react-native/codegen/hermes-parser/hermes-estree": ["hermes-estree@0.32.0", "", {}, "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ=="],
+
+    "@react-native/babel-plugin-codegen/@react-native/codegen/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "@react-native/babel-plugin-codegen/@react-native/codegen/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@react-native/codegen/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -3378,9 +3374,11 @@
 
     "jest-changed-files/jest-util/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "jest-circus/@jest/environment/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.3.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-m2xozxSfCIxjDdvbhIWazlP2i2aha/iUmbl94alpsIbd3iLTfeXgfBVbwyWogB6l++istyGZqamgA/EcqYf+Bg=="],
+    "jest-circus/@jest/environment/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.4.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA=="],
 
     "jest-circus/jest-matcher-utils/jest-diff/@jest/diff-sequences": ["@jest/diff-sequences@30.3.0", "", {}, "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA=="],
+
+    "jest-circus/jest-util/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "jest-cli/jest-util/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -3394,11 +3392,9 @@
 
     "jest-config/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
-    "jest-config/jest-environment-node/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.3.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-m2xozxSfCIxjDdvbhIWazlP2i2aha/iUmbl94alpsIbd3iLTfeXgfBVbwyWogB6l++istyGZqamgA/EcqYf+Bg=="],
+    "jest-config/jest-environment-node/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.4.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA=="],
 
     "jest-config/jest-environment-node/@jest/fake-timers/jest-message-util": ["jest-message-util@30.3.0", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@jest/types": "30.3.0", "@types/stack-utils": "^2.0.3", "chalk": "^4.1.2", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3", "pretty-format": "30.3.0", "slash": "^3.0.0", "stack-utils": "^2.0.6" } }, "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw=="],
-
-    "jest-config/jest-environment-node/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "jest-config/jest-util/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -3418,19 +3414,23 @@
 
     "jest-resolve/jest-util/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
-    "jest-runner/@jest/environment/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.3.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-m2xozxSfCIxjDdvbhIWazlP2i2aha/iUmbl94alpsIbd3iLTfeXgfBVbwyWogB6l++istyGZqamgA/EcqYf+Bg=="],
+    "jest-runner/@jest/environment/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.4.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA=="],
 
-    "jest-runner/jest-environment-node/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.3.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-m2xozxSfCIxjDdvbhIWazlP2i2aha/iUmbl94alpsIbd3iLTfeXgfBVbwyWogB6l++istyGZqamgA/EcqYf+Bg=="],
+    "jest-runner/jest-environment-node/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.4.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA=="],
 
     "jest-runner/jest-message-util/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "jest-runner/jest-util/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "jest-runtime/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "jest-runtime/jest-message-util/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
-    "jest-snapshot/expect/jest-mock/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+    "jest-runtime/jest-util/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "jest-snapshot/jest-util/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "jest-watcher/jest-util/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "jest-worker/jest-util/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -3564,8 +3564,6 @@
 
     "@jest/expect/expect/jest-message-util/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
-    "@jest/expect/expect/jest-mock/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
     "@jest/expect/expect/jest-util/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@jest/expect/expect/jest-util/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -3576,11 +3574,21 @@
 
     "@jest/globals/@jest/environment/@jest/fake-timers/jest-message-util/pretty-format": ["pretty-format@30.3.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ=="],
 
+    "@jest/globals/@jest/environment/@jest/fake-timers/jest-util/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+
     "@jest/globals/@jest/environment/@jest/fake-timers/jest-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "@jest/globals/jest-mock/jest-util/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@jest/globals/jest-mock/jest-util/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@jest/reporters/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@react-native/babel-plugin-codegen/@react-native/codegen/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@react-native/babel-plugin-codegen/@react-native/codegen/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "@react-native/babel-plugin-codegen/@react-native/codegen/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "babel-jest/@jest/transform/@jest/types/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
 
@@ -3607,8 +3615,6 @@
     "jest-config/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "jest-runtime/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "jest-snapshot/expect/jest-mock/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "log-symbols/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
@@ -3675,6 +3681,8 @@
     "@jest/globals/@jest/environment/@jest/fake-timers/jest-message-util/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@jest/globals/@jest/environment/@jest/fake-timers/jest-message-util/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "@jest/globals/@jest/environment/@jest/fake-timers/jest-util/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@jest/globals/@jest/environment/@jest/fake-timers/jest-util/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -72,41 +72,42 @@ See [react-hooks.md](react-hooks.md).
 
 `storage` exposes raw and cross-item utilities:
 
-| Method                                           | Purpose                                                       |
-| ------------------------------------------------ | ------------------------------------------------------------- |
-| `clear(scope)`                                   | Clear one scope.                                              |
-| `clearAll()`                                     | Clear Memory, Disk, and Secure scopes.                        |
-| `clearNamespace(namespace, scope)`               | Remove keys under `namespace:`.                               |
-| `subscribe(scope, listener)`                     | Subscribe to raw scope-level change events.                   |
-| `subscribeKey(scope, key, listener)`             | Subscribe to raw events for one key.                          |
-| `subscribePrefix(scope, prefix, listener)`       | Subscribe to raw events for matching key prefixes.            |
-| `subscribeNamespace(namespace, scope, listener)` | Subscribe to raw events for `namespace:` keys.                |
-| `setEventObserver(observer)`                     | Receive all change events for devtools or logging.            |
-| `clearBiometric()`                               | Clear biometric Secure entries.                               |
-| `has(key, scope)`                                | Check for a raw key.                                          |
-| `getAllKeys(scope)`                              | List raw keys.                                                |
-| `getKeysByPrefix(prefix, scope)`                 | List raw keys with a prefix.                                  |
-| `getByPrefix(prefix, scope)`                     | Read raw string values by prefix.                             |
-| `getAll(scope)`                                  | Read all raw string values in a scope.                        |
-| `size(scope)`                                    | Return approximate scope entry count.                         |
-| `setAccessControl(accessControl)`                | Set the default Secure access control level.                  |
-| `setSecureWritesAsync(enabled)`                  | Toggle Android secure writes between sync and async modes.    |
-| `setDiskWritesAsync(enabled)`                    | Toggle coalesced Disk write behavior.                         |
-| `flushDiskWrites()`                              | Flush pending Disk writes.                                    |
-| `flushSecureWrites()`                            | Flush pending Secure writes.                                  |
-| `setKeychainAccessGroup(group)`                  | Configure iOS Keychain access group.                          |
-| `setMetricsObserver(observer)`                   | Receive operation timing events.                              |
-| `getMetricsSnapshot()`                           | Read aggregated metrics.                                      |
-| `resetMetrics()`                                 | Clear metrics counters.                                       |
-| `getCapabilities()`                              | Read runtime storage capabilities.                            |
-| `getSecurityCapabilities()`                      | Read secure backend capability metadata.                      |
-| `getSecureMetadata(key)`                         | Read secure metadata for one key without returning its value. |
-| `getAllSecureMetadata()`                         | Read secure metadata for all secure keys without values.      |
-| `getString(key, scope)`                          | Read a raw string.                                            |
-| `setString(key, value, scope)`                   | Write a raw string.                                           |
-| `deleteString(key, scope)`                       | Remove a raw key.                                             |
-| `export(scope)`                                  | Snapshot raw strings from one scope.                          |
-| `import(data, scope)`                            | Bulk import raw strings.                                      |
+| Method                                           | Purpose                                                                                   |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| `clear(scope)`                                   | Clear one scope.                                                                          |
+| `clearAll()`                                     | Clear Memory, Disk, and Secure scopes.                                                    |
+| `clearNamespace(namespace, scope)`               | Remove keys under `namespace:`.                                                           |
+| `subscribe(scope, listener)`                     | Subscribe to raw scope-level change events.                                               |
+| `subscribeKey(scope, key, listener)`             | Subscribe to raw events for one key.                                                      |
+| `subscribePrefix(scope, prefix, listener)`       | Subscribe to raw events for matching key prefixes.                                        |
+| `subscribeNamespace(namespace, scope, listener)` | Subscribe to raw events for `namespace:` keys.                                            |
+| `setEventObserver(observer, options?)`           | Receive all change events for devtools or logging. Secure values are redacted by default. |
+| `clearBiometric()`                               | Clear biometric Secure entries.                                                           |
+| `has(key, scope)`                                | Check for a raw key.                                                                      |
+| `getAllKeys(scope)`                              | List raw keys.                                                                            |
+| `getKeysByPrefix(prefix, scope)`                 | List raw keys with a prefix.                                                              |
+| `getByPrefix(prefix, scope)`                     | Read raw string values by prefix.                                                         |
+| `getAll(scope)`                                  | Read all raw string values in a scope.                                                    |
+| `size(scope)`                                    | Return approximate scope entry count.                                                     |
+| `setAccessControl(accessControl)`                | Set the default Secure access control level.                                              |
+| `setSecureWritesAsync(enabled)`                  | Toggle Android secure writes between sync and async modes.                                |
+| `setDiskWritesAsync(enabled)`                    | Toggle coalesced Disk write behavior.                                                     |
+| `flushDiskWrites()`                              | Flush pending Disk writes.                                                                |
+| `flushSecureWrites()`                            | Flush pending Secure writes.                                                              |
+| `setKeychainAccessGroup(group)`                  | Configure iOS Keychain access group.                                                      |
+| `setMetricsObserver(observer)`                   | Receive operation timing events.                                                          |
+| `getMetricsSnapshot()`                           | Read aggregated metrics.                                                                  |
+| `resetMetrics()`                                 | Clear metrics counters.                                                                   |
+| `getCapabilities()`                              | Read runtime storage capabilities.                                                        |
+| `getSecurityCapabilities()`                      | Read secure backend capability metadata.                                                  |
+| `getSecureMetadata(key)`                         | Read secure metadata for one key without returning its value.                             |
+| `getAllSecureMetadata()`                         | Read secure metadata for all secure keys without values.                                  |
+| `getString(key, scope)`                          | Read a raw string.                                                                        |
+| `setString(key, value, scope)`                   | Write a raw string.                                                                       |
+| `deleteString(key, scope)`                       | Remove a raw key.                                                                         |
+| `export(scope, options?)`                        | Snapshot raw strings from one scope. Secure scope requires explicit unsafe opt-in.        |
+| `exportSecureUnsafe()`                           | Snapshot raw Secure strings for short-lived migration workflows.                          |
+| `import(data, scope)`                            | Bulk import raw strings.                                                                  |
 
 Raw string APIs bypass item serialization and validation. Prefer `StorageItem<T>` unless you are migrating, exporting/importing, or writing a custom integration.
 
@@ -115,7 +116,7 @@ const diskSnapshot = storage.export(StorageScope.Disk);
 storage.import(diskSnapshot, StorageScope.Disk);
 ```
 
-Secure exports contain raw secret values. Do not log `storage.export(StorageScope.Secure)` output or attach it to diagnostics, analytics, crash reports, or support bundles.
+Secure exports contain raw secret values. `storage.export(StorageScope.Secure)` throws unless called with `{ includeSecureValues: true }`; `storage.exportSecureUnsafe()` is the explicit equivalent. Do not log Secure exports or attach them to diagnostics, analytics, crash reports, or support bundles.
 
 ## Event Subscriptions
 
@@ -148,6 +149,8 @@ storage.setEventObserver((event) => {
   }
 });
 ```
+
+`setEventObserver()` redacts Secure `oldValue` and `newValue` fields by default. Pass `{ redactSecureValues: false }` only for in-memory debugging paths that never persist logs. Raw `subscribe*()` APIs preserve values for state integrations.
 
 Local batch APIs emit one `type: "batch"` envelope to scope and prefix/namespace listeners. Key subscribers receive the matching per-key change so direct key integrations do not need to unpack batch envelopes. Secure events can include raw secret values; do not log Secure event payloads in production.
 

--- a/docs/batch-transactions-migrations.md
+++ b/docs/batch-transactions-migrations.md
@@ -82,7 +82,7 @@ storage.import(snapshot, StorageScope.Disk);
 
 For Memory scope, import is atomic: all keys are written before listeners fire. For Disk and Secure, import delegates to native or web batch paths.
 
-Secure exports contain raw secret values. Do not log them or include them in diagnostics, analytics, crash reports, or support bundles.
+Secure exports contain raw secret values. `storage.export(StorageScope.Secure)` requires `{ includeSecureValues: true }`; `storage.exportSecureUnsafe()` is the explicit equivalent. Do not log Secure exports or include them in diagnostics, analytics, crash reports, or support bundles.
 
 ## Transactions
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -278,7 +278,7 @@ storage.setEventObserver((event) => {
 });
 ```
 
-Use `subscribePrefix()` or `subscribeNamespace()` for targeted integrations. Use `setEventObserver()` for devtools-style logging. Secure events can include raw secret values, so filter them out of logs.
+Use `subscribePrefix()` or `subscribeNamespace()` for targeted integrations. Use `setEventObserver()` for devtools-style logging; it redacts Secure values by default. Raw Secure subscriptions can include secret values, so filter them out of logs.
 
 ## Capability Checks
 

--- a/docs/secure-storage.md
+++ b/docs/secure-storage.md
@@ -4,6 +4,8 @@ Secure scope is for secrets: refresh tokens, credentials, API tokens, and device
 
 Use Disk scope for non-secret persisted state. Secure storage has stronger boundaries but more platform rules, especially around biometric prompts, device lock state, and backup/restore behavior.
 
+Keep Secure values small. Platform secure stores are optimized for credentials and keys, not large payloads or support bundles.
+
 ## Store a Secure Token
 
 ```ts
@@ -116,12 +118,12 @@ const allKeys = storage.getAllSecureMetadata();
 
 ## Secure Export Warning
 
-`storage.export(StorageScope.Secure)` returns raw secret values so it can round-trip with `storage.import(data, StorageScope.Secure)`.
+`storage.export(StorageScope.Secure)` throws unless you explicitly opt into exposing raw secret values. Use `storage.exportSecureUnsafe()` or `storage.export(StorageScope.Secure, { includeSecureValues: true })` only when you need to round-trip with `storage.import(data, StorageScope.Secure)`.
 
 ```ts
 import { storage, StorageScope } from "react-native-nitro-storage";
 
-const secureSnapshot = storage.export(StorageScope.Secure);
+const secureSnapshot = storage.exportSecureUnsafe();
 storage.import(secureSnapshot, StorageScope.Secure);
 ```
 
@@ -129,9 +131,18 @@ Only keep Secure exports in memory for the shortest possible workflow. Do not lo
 
 ## Secure Event Warning
 
-Secure scope event subscriptions and `storage.setEventObserver()` can receive raw secret values in `oldValue`, `newValue`, or batch `changes`.
+Secure scope event subscriptions can receive raw secret values in `oldValue`, `newValue`, or batch `changes`. `storage.setEventObserver()` redacts Secure values by default because observer callbacks are commonly used for logging and devtools.
 
-Use Secure events for in-memory coordination only. Do not log Secure event payloads or send them to analytics, crash reporting, support bundles, or devtools sessions that persist outside the device.
+Use Secure events for in-memory coordination only. Do not log Secure event payloads or send them to analytics, crash reporting, support bundles, or devtools sessions that persist outside the device. Pass `{ redactSecureValues: false }` to `setEventObserver()` only for local, non-persistent debugging.
+
+## Android Backup Rules
+
+Android secure storage uses encrypted SharedPreferences. Restored encrypted preference files can become unreadable when the app's Keystore keys are not restored with them. The Expo plugin configures backup exclusions for Nitro Storage secure files by default:
+
+- `NitroStorageSecure.xml`
+- `NitroStorageBiometric.xml`
+
+If you disable `configureAndroidBackup` or maintain custom Android backup XML, add equivalent exclusions for both cloud backup and device transfer.
 
 ## Locked Keychain Errors
 

--- a/docs/web-backends.md
+++ b/docs/web-backends.md
@@ -33,9 +33,12 @@ Optional methods improve performance and observability:
 - `size()`
 - `subscribe(listener)`
 - `flush()`
+- `close()`
 - `name`
 
 `subscribe(listener)` should report `{ key, newValue }` changes. Use `key: null` when the whole backend is cleared.
+
+`close()` should release backend-owned resources such as database handles or broadcast channels. Nitro Storage calls it when a configured Disk or Secure backend is replaced.
 
 ## Disk Backend
 
@@ -94,6 +97,8 @@ setWebSecureStorageBackend(backend);
 ```
 
 Reads are synchronous because they are served from memory after initial load. Writes update memory first and persist to IndexedDB in the background.
+
+The IndexedDB backend exposes `close()` and rejects later synchronous operations after it is closed.
 
 ## Cross-tab Updates
 

--- a/package.json
+++ b/package.json
@@ -30,29 +30,29 @@
     "example:prebuild:clean": "bun run --cwd apps/example prebuild:clean"
   },
   "devDependencies": {
-    "@swc/core": "^1.15.30",
+    "@swc/core": "^1.15.33",
     "@swc/jest": "^0.2.39",
     "@types/jest": "^30.0.0",
-    "@types/node": "^25.6.0",
+    "@types/node": "^25.7.0",
     "eslint-config-expo-magic": "^2.4.0",
-    "jest": "^30.3.0",
-    "nitrogen": "0.35.5",
+    "jest": "30.3.0",
+    "nitrogen": "0.35.6",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.6",
     "react-native-builder-bob": "^0.40.18",
-    "react-native-nitro-modules": "0.35.5",
+    "react-native-nitro-modules": "0.35.6",
     "react-test-renderer": "19.2.0",
     "rimraf": "^6.1.3",
     "ts-jest": "^29.4.9",
-    "turbo": "^2.9.6",
+    "turbo": "^2.9.12",
     "typescript": "^5.9.3"
   },
   "overrides": {
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.6",
-    "react-native-nitro-modules": "0.35.5",
+    "react-native-nitro-modules": "0.35.6",
     "@types/react": "~19.2.0"
   },
   "packageManager": "bun@1.3.11"

--- a/packages/react-native-nitro-storage/android/build.gradle
+++ b/packages/react-native-nitro-storage/android/build.gradle
@@ -28,10 +28,10 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
-  namespace "com.nitrostorage"
+  namespace = "com.nitrostorage"
 
   // Use values from root project or defaults
-  ndkVersion getExtOrDefault("ndkVersion")
+  ndkVersion = getExtOrDefault("ndkVersion")
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {
@@ -55,8 +55,8 @@ android {
   }
 
   buildFeatures {
-    buildConfig true
-    prefab true
+    buildConfig = true
+    prefab = true
   }
 
   compileOptions {
@@ -79,7 +79,7 @@ repositories {
 dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
-  implementation "androidx.security:security-crypto:1.1.0-alpha06"
+  implementation "androidx.security:security-crypto:1.1.0"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.0"
   implementation project(":react-native-nitro-modules")
 }

--- a/packages/react-native-nitro-storage/android/src/main/java/com/nitrostorage/AndroidStorageAdapter.kt
+++ b/packages/react-native-nitro-storage/android/src/main/java/com/nitrostorage/AndroidStorageAdapter.kt
@@ -1,10 +1,11 @@
+@file:Suppress("DEPRECATION")
+
 package com.nitrostorage
 
 import android.content.Context
 import android.security.keystore.KeyPermanentlyInvalidatedException
 import android.security.keystore.UserNotAuthenticatedException
 import android.content.SharedPreferences
-import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import java.security.InvalidKeyException
@@ -71,7 +72,6 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
                 .build()
             initializeEncryptedPreferences("NitroStorageBiometric", bioKey)
         } catch (e: Exception) {
-            Log.e("NitroStorage", "Biometric storage unavailable: ${e.message}")
             throw e.wrapStorageException(
                 "NitroStorage: Biometric storage is not available on this device. " +
                     "Ensure biometric hardware is present and credentials are enrolled.",
@@ -96,7 +96,6 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
         } catch (e: Exception) {
             when {
                 e.hasCause(AEADBadTagException::class.java) -> {
-                    Log.w("NitroStorage", "Corrupted encryption keys for $name, attempting recovery...")
                     clearCorruptedStorage(name, key)
                     val freshAlias = if (name == "NitroStorageBiometric") biometricMasterKeyAlias else masterKeyAlias
                     val freshKey = MasterKey.Builder(context, freshAlias)
@@ -142,9 +141,7 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
                 else -> masterKeyAlias
             }
             keyStore.deleteEntry(alias)
-            Log.i("NitroStorage", "Cleared corrupted storage: $name")
-        } catch (e: Exception) {
-            Log.e("NitroStorage", "Failed to clear corrupted storage $name: ${e.message}", e)
+        } catch (_: Exception) {
         }
     }
 
@@ -153,7 +150,6 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
             prefs.getString(key, null)
         } catch (e: Exception) {
             if (e.hasCause(AEADBadTagException::class.java)) {
-                Log.w("NitroStorage", "Corrupt entry for key '$key', removing")
                 prefs.edit().remove(key).commit()
                 null
             } else {
@@ -198,8 +194,7 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
             keys.addAll(encryptedPreferences.all.keys.filter { !it.startsWith(INTERNAL_PREFIX) })
             try {
                 keys.addAll(biometricPreferences.all.keys.filter { !it.startsWith(INTERNAL_PREFIX) })
-            } catch (e: Exception) {
-                Log.d("NitroStorage", "Biometric storage unavailable: ${e.message}")
+            } catch (_: Exception) {
             }
             val built = keys.toTypedArray()
             secureKeysCache = built
@@ -369,8 +364,7 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
                 inst.applySecureEditor(inst.encryptedPreferences.edit().remove(key))
                 try {
                     inst.applySecureEditor(inst.biometricPreferences.edit().remove(key))
-                } catch (e: Exception) {
-                    Log.d("NitroStorage", "Biometric storage unavailable: ${e.message}")
+                } catch (_: Exception) {
                 }
                 inst.invalidateSecureKeysCache()
             }
@@ -391,8 +385,7 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
                         biometricEditor.remove(key)
                     }
                     inst.applySecureEditor(biometricEditor)
-                } catch (e: Exception) {
-                    Log.d("NitroStorage", "Biometric storage unavailable: ${e.message}")
+                } catch (_: Exception) {
                 }
                 inst.invalidateSecureKeysCache()
             }
@@ -404,8 +397,7 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
             val hasInEncrypted = inst.encryptedPreferences.contains(key)
             val hasInBiometric = try {
                 inst.biometricPreferences.contains(key)
-            } catch (e: Exception) {
-                Log.d("NitroStorage", "Biometric storage unavailable: ${e.message}")
+            } catch (_: Exception) {
                 false
             }
             return hasInEncrypted || hasInBiometric
@@ -433,8 +425,7 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
             inst.applySecureEditor(inst.encryptedPreferences.edit().clear())
             try {
                 inst.applySecureEditor(inst.biometricPreferences.edit().clear())
-            } catch (e: Exception) {
-                Log.d("NitroStorage", "Biometric storage unavailable: ${e.message}")
+            } catch (_: Exception) {
             }
             inst.invalidateSecureKeysCache()
         }
@@ -466,8 +457,7 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
             val inst = getInstanceOrThrow()
             return try {
                 inst.getSecureSafe(inst.biometricPreferences, key)
-            } catch (e: Exception) {
-                Log.d("NitroStorage", "Biometric storage unavailable: ${e.message}")
+            } catch (_: Exception) {
                 null
             }
         }
@@ -478,8 +468,7 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
             try {
                 inst.applySecureEditor(inst.biometricPreferences.edit().remove(key))
                 inst.invalidateSecureKeysCache()
-            } catch (e: Exception) {
-                Log.d("NitroStorage", "Biometric storage unavailable: ${e.message}")
+            } catch (_: Exception) {
             }
         }
 
@@ -487,8 +476,7 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
         fun hasSecureBiometric(key: String): Boolean {
             return try {
                 getInstanceOrThrow().biometricPreferences.contains(key)
-            } catch (e: Exception) {
-                Log.d("NitroStorage", "Biometric storage unavailable: ${e.message}")
+            } catch (_: Exception) {
                 false
             }
         }
@@ -499,8 +487,7 @@ class AndroidStorageAdapter private constructor(private val context: Context) {
             try {
                 inst.applySecureEditor(inst.biometricPreferences.edit().clear())
                 inst.invalidateSecureKeysCache()
-            } catch (e: Exception) {
-                Log.d("NitroStorage", "Biometric storage unavailable: ${e.message}")
+            } catch (_: Exception) {
             }
         }
     }

--- a/packages/react-native-nitro-storage/app.plugin.js
+++ b/packages/react-native-nitro-storage/app.plugin.js
@@ -2,16 +2,100 @@ const {
   withInfoPlist,
   withAndroidManifest,
   withMainApplication,
+  withDangerousMod,
   createRunOncePlugin,
 } = require("@expo/config-plugins");
+const fs = require("fs");
+const path = require("path");
+
+const DATA_EXTRACTION_RULES_RESOURCE =
+  "@xml/nitro_storage_data_extraction_rules";
+const FULL_BACKUP_CONTENT_RESOURCE = "@xml/nitro_storage_full_backup_content";
+
+const secureSharedPrefs = [
+  "NitroStorageSecure.xml",
+  "NitroStorageBiometric.xml",
+];
+
+function sharedPrefsExcludes(indent = "    ") {
+  return secureSharedPrefs
+    .map((file) => `${indent}<exclude domain="sharedpref" path="${file}" />`)
+    .join("\n");
+}
+
+function dataExtractionRulesXml() {
+  const excludes = sharedPrefsExcludes("    ");
+  return `<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+  <cloud-backup>
+${excludes}
+  </cloud-backup>
+  <device-transfer>
+${excludes}
+  </device-transfer>
+</data-extraction-rules>
+`;
+}
+
+function fullBackupContentXml() {
+  return `<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+${sharedPrefsExcludes("  ")}
+</full-backup-content>
+`;
+}
+
+function ensureBackupAttributes(androidManifest) {
+  const application = androidManifest.manifest.application?.[0];
+  if (!application) {
+    return;
+  }
+
+  application.$ = application.$ || {};
+  if (!application.$["android:dataExtractionRules"]) {
+    application.$["android:dataExtractionRules"] =
+      DATA_EXTRACTION_RULES_RESOURCE;
+  }
+  if (!application.$["android:fullBackupContent"]) {
+    application.$["android:fullBackupContent"] = FULL_BACKUP_CONTENT_RESOURCE;
+  }
+}
+
+function writeAndroidBackupFiles(projectRoot) {
+  const xmlDir = path.join(
+    projectRoot,
+    "android",
+    "app",
+    "src",
+    "main",
+    "res",
+    "xml",
+  );
+  fs.mkdirSync(xmlDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(xmlDir, "nitro_storage_data_extraction_rules.xml"),
+    dataExtractionRulesXml(),
+  );
+  fs.writeFileSync(
+    path.join(xmlDir, "nitro_storage_full_backup_content.xml"),
+    fullBackupContentXml(),
+  );
+}
 
 const withNitroStorage = (config, props = {}) => {
   const defaultFaceIDPermission =
     "Allow $(PRODUCT_NAME) to use Face ID for secure authentication";
-  const { faceIDPermission, addBiometricPermissions = false } = props;
+  const {
+    faceIDPermission,
+    addBiometricPermissions = false,
+    configureAndroidBackup = true,
+  } = props;
 
   config = withInfoPlist(config, (config) => {
-    if (typeof faceIDPermission === "string" && faceIDPermission.trim() !== "") {
+    if (
+      typeof faceIDPermission === "string" &&
+      faceIDPermission.trim() !== ""
+    ) {
       config.modResults.NSFaceIDUsageDescription = faceIDPermission;
     } else if (!config.modResults.NSFaceIDUsageDescription) {
       config.modResults.NSFaceIDUsageDescription = defaultFaceIDPermission;
@@ -20,6 +104,10 @@ const withNitroStorage = (config, props = {}) => {
   });
 
   config = withAndroidManifest(config, (config) => {
+    if (configureAndroidBackup) {
+      ensureBackupAttributes(config.modResults);
+    }
+
     if (!addBiometricPermissions) {
       return config;
     }
@@ -38,10 +126,10 @@ const withNitroStorage = (config, props = {}) => {
     };
 
     const hasBiometric = permissions.some(
-      (p) => p.$?.["android:name"] === "android.permission.USE_BIOMETRIC"
+      (p) => p.$?.["android:name"] === "android.permission.USE_BIOMETRIC",
     );
     const hasFingerprint = permissions.some(
-      (p) => p.$?.["android:name"] === "android.permission.USE_FINGERPRINT"
+      (p) => p.$?.["android:name"] === "android.permission.USE_FINGERPRINT",
     );
 
     if (!hasBiometric) {
@@ -53,6 +141,16 @@ const withNitroStorage = (config, props = {}) => {
 
     return config;
   });
+
+  if (configureAndroidBackup) {
+    config = withDangerousMod(config, [
+      "android",
+      async (config) => {
+        writeAndroidBackupFiles(config.modRequest.projectRoot);
+        return config;
+      },
+    ]);
+  }
 
   config = withMainApplication(config, (config) => {
     const { modResults } = config;
@@ -67,13 +165,13 @@ const withNitroStorage = (config, props = {}) => {
         if (!contents.includes(importStatement)) {
           modResults.contents = contents.replace(
             /(package .*;\n)/,
-            `$1\n${importStatement}\n`
+            `$1\n${importStatement}\n`,
           );
         }
 
         modResults.contents = modResults.contents.replace(
           /(super\.onCreate\(\);)/,
-          `$1\n${initStatement}`
+          `$1\n${initStatement}`,
         );
       }
     } else if (language === "kt") {
@@ -84,13 +182,13 @@ const withNitroStorage = (config, props = {}) => {
         if (!contents.includes(importStatement)) {
           modResults.contents = contents.replace(
             /(package .*\n)/,
-            `$1\n${importStatement}\n`
+            `$1\n${importStatement}\n`,
           );
         }
 
         modResults.contents = modResults.contents.replace(
           /(super\.onCreate\(\))/,
-          `$1\n${initStatement}`
+          `$1\n${initStatement}`,
         );
       }
     }
@@ -104,5 +202,12 @@ const withNitroStorage = (config, props = {}) => {
 module.exports = createRunOncePlugin(
   withNitroStorage,
   "react-native-nitro-storage",
-  "1.0.0"
+  "1.0.0",
 );
+module.exports.withNitroStorage = withNitroStorage;
+module.exports._internal = {
+  dataExtractionRulesXml,
+  fullBackupContentXml,
+  ensureBackupAttributes,
+  writeAndroidBackupFiles,
+};

--- a/packages/react-native-nitro-storage/package.json
+++ b/packages/react-native-nitro-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-storage",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Synchronous React Native storage powered by Nitro Modules and JSI: typed Memory, Disk, Keychain/Android Keystore secure storage, biometric auth, MMKV migration, Expo, Zustand/Jotai persistence, and web IndexedDB support.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -112,7 +112,7 @@
   },
   "devDependencies": {
     "@expo/config-plugins": "^55.0.8",
-    "@react-native/babel-preset": "^0.83.6",
+    "@react-native/babel-preset": "^0.83.9",
     "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/react-native": "^13.3.3",
     "@types/react": "~19.2.0"
@@ -120,7 +120,7 @@
   "peerDependencies": {
     "react": ">=18.2.0",
     "react-native": ">=0.75.0",
-    "react-native-nitro-modules": ">=0.35.5"
+    "react-native-nitro-modules": ">=0.35.6"
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/packages/react-native-nitro-storage/scripts/benchmark-check.js
+++ b/packages/react-native-nitro-storage/scripts/benchmark-check.js
@@ -3,7 +3,12 @@ const fs = require("fs");
 const { performance } = require("perf_hooks");
 
 const packageRoot = path.join(__dirname, "..");
-const entrypointPath = path.join(packageRoot, "lib", "commonjs", "index.web.js");
+const entrypointPath = path.join(
+  packageRoot,
+  "lib",
+  "commonjs",
+  "index.web.js",
+);
 
 let storageModule;
 if (!fs.existsSync(entrypointPath)) {
@@ -127,9 +132,12 @@ const batchItems = Array.from({ length: 32 }, (_, index) =>
     key: `__benchmark_batch_${index}__`,
     scope: StorageScope.Memory,
     defaultValue: 0,
-  })
+  }),
 );
-const batchPayload = batchItems.map((item, index) => ({ item, value: index + 1 }));
+const batchPayload = batchItems.map((item, index) => ({
+  item,
+  value: index + 1,
+}));
 const batchIterations = 400;
 const batchOperationsPerIteration = batchItems.length * 3;
 const batchMetric = measureBestOf(
@@ -141,7 +149,7 @@ const batchMetric = measureBestOf(
       getBatch(batchItems, StorageScope.Memory);
       removeBatch(batchItems, StorageScope.Memory);
     }
-  }
+  },
 );
 
 const diskCounter = createStorageItem({
@@ -198,37 +206,37 @@ metrics.forEach(printMetric);
 const failures = [];
 if (setMetric.opsPerSecond < thresholds.memorySetOpsPerSecond) {
   failures.push(
-    `memory:set dropped below ${thresholds.memorySetOpsPerSecond.toLocaleString()} ops/s`
+    `memory:set dropped below ${thresholds.memorySetOpsPerSecond.toLocaleString()} ops/s`,
   );
 }
 if (getMetric.opsPerSecond < thresholds.memoryGetOpsPerSecond) {
   failures.push(
-    `memory:get dropped below ${thresholds.memoryGetOpsPerSecond.toLocaleString()} ops/s`
+    `memory:get dropped below ${thresholds.memoryGetOpsPerSecond.toLocaleString()} ops/s`,
   );
 }
 if (batchMetric.opsPerSecond < thresholds.memoryBatchOpsPerSecond) {
   failures.push(
-    `memory:batch dropped below ${thresholds.memoryBatchOpsPerSecond.toLocaleString()} ops/s`
+    `memory:batch dropped below ${thresholds.memoryBatchOpsPerSecond.toLocaleString()} ops/s`,
   );
 }
 if (diskSetMetric.opsPerSecond < thresholds.diskSetOpsPerSecond) {
   failures.push(
-    `disk:set dropped below ${thresholds.diskSetOpsPerSecond.toLocaleString()} ops/s`
+    `disk:set dropped below ${thresholds.diskSetOpsPerSecond.toLocaleString()} ops/s`,
   );
 }
 if (diskGetMetric.opsPerSecond < thresholds.diskGetOpsPerSecond) {
   failures.push(
-    `disk:get dropped below ${thresholds.diskGetOpsPerSecond.toLocaleString()} ops/s`
+    `disk:get dropped below ${thresholds.diskGetOpsPerSecond.toLocaleString()} ops/s`,
   );
 }
 if (secureSetMetric.opsPerSecond < thresholds.secureSetOpsPerSecond) {
   failures.push(
-    `secure:set dropped below ${thresholds.secureSetOpsPerSecond.toLocaleString()} ops/s`
+    `secure:set dropped below ${thresholds.secureSetOpsPerSecond.toLocaleString()} ops/s`,
   );
 }
 if (secureGetMetric.opsPerSecond < thresholds.secureGetOpsPerSecond) {
   failures.push(
-    `secure:get dropped below ${thresholds.secureGetOpsPerSecond.toLocaleString()} ops/s`
+    `secure:get dropped below ${thresholds.secureGetOpsPerSecond.toLocaleString()} ops/s`,
   );
 }
 

--- a/packages/react-native-nitro-storage/scripts/check-pack-contents.js
+++ b/packages/react-native-nitro-storage/scripts/check-pack-contents.js
@@ -29,6 +29,13 @@ const forbiddenPatterns = [
   /^cpp\/build\//,
   /^android\/build\//,
   /^android\/\.cxx\//,
+  /^apps\/example\/(?:android|ios)\//,
+  /(?:^|\/)\.env(?:\.|$)/,
+  /(?:^|\/)npm-debug\.log$/,
+  /(?:^|\/)yarn-error\.log$/,
+  /(?:^|\/)bun(?:fig)?\.lockb$/,
+  /(?:^|\/)[^/]*\.(?:jks|keystore|p8|p12|pem|mobileprovision)$/,
+  /(?:^|\/)[^/]*\.tgz$/,
   /(?:^|\/)[^/]*Test\.cpp$/,
 ];
 

--- a/packages/react-native-nitro-storage/src/__tests__/app-plugin.test.js
+++ b/packages/react-native-nitro-storage/src/__tests__/app-plugin.test.js
@@ -1,0 +1,93 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const { _internal } = require("../../app.plugin.js");
+
+describe("Expo config plugin", () => {
+  it("adds Android backup attributes when missing", () => {
+    const manifest = {
+      manifest: {
+        application: [{ $: {} }],
+      },
+    };
+
+    _internal.ensureBackupAttributes(manifest);
+
+    expect(manifest.manifest.application[0].$).toMatchObject({
+      "android:dataExtractionRules": "@xml/nitro_storage_data_extraction_rules",
+      "android:fullBackupContent": "@xml/nitro_storage_full_backup_content",
+    });
+  });
+
+  it("preserves existing Android backup attributes", () => {
+    const manifest = {
+      manifest: {
+        application: [
+          {
+            $: {
+              "android:dataExtractionRules": "@xml/custom_data_rules",
+              "android:fullBackupContent": "@xml/custom_backup_rules",
+            },
+          },
+        ],
+      },
+    };
+
+    _internal.ensureBackupAttributes(manifest);
+
+    expect(manifest.manifest.application[0].$).toMatchObject({
+      "android:dataExtractionRules": "@xml/custom_data_rules",
+      "android:fullBackupContent": "@xml/custom_backup_rules",
+    });
+  });
+
+  it("generates backup XML that excludes secure preference files", () => {
+    expect(_internal.dataExtractionRulesXml()).toContain(
+      '<exclude domain="sharedpref" path="NitroStorageSecure.xml" />',
+    );
+    expect(_internal.dataExtractionRulesXml()).toContain(
+      '<exclude domain="sharedpref" path="NitroStorageBiometric.xml" />',
+    );
+    expect(_internal.fullBackupContentXml()).toContain(
+      '<exclude domain="sharedpref" path="NitroStorageSecure.xml" />',
+    );
+    expect(_internal.fullBackupContentXml()).toContain(
+      '<exclude domain="sharedpref" path="NitroStorageBiometric.xml" />',
+    );
+  });
+
+  it("writes Android backup XML files", () => {
+    const projectRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nitro-storage-plugin-"),
+    );
+
+    try {
+      _internal.writeAndroidBackupFiles(projectRoot);
+      const xmlDir = path.join(
+        projectRoot,
+        "android",
+        "app",
+        "src",
+        "main",
+        "res",
+        "xml",
+      );
+
+      expect(
+        fs.readFileSync(
+          path.join(xmlDir, "nitro_storage_data_extraction_rules.xml"),
+          "utf8",
+        ),
+      ).toContain("NitroStorageSecure.xml");
+      expect(
+        fs.readFileSync(
+          path.join(xmlDir, "nitro_storage_full_backup_content.xml"),
+          "utf8",
+        ),
+      ).toContain("NitroStorageBiometric.xml");
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/react-native-nitro-storage/src/__tests__/indexeddb-backend.test.ts
+++ b/packages/react-native-nitro-storage/src/__tests__/indexeddb-backend.test.ts
@@ -139,6 +139,7 @@ function makeFakeIDB(): {
       transaction(storeName: string, mode: IDBTransactionMode = "readonly") {
         return makeTransaction(entries, storeName, mode);
       },
+      close() {},
     };
 
     const req: {
@@ -247,6 +248,7 @@ describe("createIndexedDBBackend", () => {
     expect(typeof backend.getAllKeys).toBe("function");
     expect(typeof backend.flush).toBe("function");
     expect(typeof backend.subscribe).toBe("function");
+    expect(typeof backend.close).toBe("function");
   });
 
   it("getItem returns null for a key that was never set", async () => {
@@ -407,6 +409,17 @@ describe("createIndexedDBBackend", () => {
     });
   });
 
+  it("closes the backend and rejects further synchronous operations", async () => {
+    const backend = await createIndexedDBBackend("close-db", "kv");
+    backend.setItem("key", "value");
+
+    backend.close?.();
+    backend.close?.();
+
+    expect(() => backend.getItem("key")).toThrow(/closed/);
+    expect(() => backend.setItem("other", "value")).toThrow(/closed/);
+  });
+
   it("surfaces async queue failures through onError", async () => {
     Object.defineProperty(globalThis, "indexedDB", {
       value: {
@@ -418,6 +431,7 @@ describe("createIndexedDBBackend", () => {
             createObjectStore() {
               return {};
             },
+            close() {},
             transaction(_storeName: string, mode: IDBTransactionMode) {
               if (mode === "readwrite") {
                 throw new Error("write failed");

--- a/packages/react-native-nitro-storage/src/__tests__/storage.test.ts
+++ b/packages/react-native-nitro-storage/src/__tests__/storage.test.ts
@@ -2832,6 +2832,64 @@ describe("memory scope optimizations", () => {
 
     storage.setEventObserver(undefined);
   });
+
+  it("redacts secure values for the global event observer by default", () => {
+    const events: unknown[] = [];
+
+    storage.setEventObserver((event) => {
+      events.push(event);
+    });
+
+    storage.setString("secure:event", "secret-value", StorageScope.Secure);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "key",
+      scope: StorageScope.Secure,
+      key: "secure:event",
+      oldValue: undefined,
+      newValue: "[secure]",
+    });
+
+    storage.setEventObserver(undefined);
+  });
+
+  it("allows explicit raw secure values for the global event observer", () => {
+    const events: unknown[] = [];
+
+    storage.setEventObserver(
+      (event) => {
+        events.push(event);
+      },
+      { redactSecureValues: false },
+    );
+
+    storage.setString("secure:event:raw", "secret-value", StorageScope.Secure);
+
+    expect(events[0]).toMatchObject({
+      type: "key",
+      scope: StorageScope.Secure,
+      key: "secure:event:raw",
+      newValue: "secret-value",
+    });
+
+    storage.setEventObserver(undefined);
+  });
+
+  it("requires explicit opt-in for secure raw export", () => {
+    mockHybridObject.getAllKeys.mockReturnValue(["secure:export"]);
+    mockHybridObject.getBatch.mockReturnValue(["secret-value"]);
+
+    expect(() => storage.export(StorageScope.Secure)).toThrow(
+      /exporting Secure scope exposes raw secret values/,
+    );
+    expect(
+      storage.export(StorageScope.Secure, { includeSecureValues: true }),
+    ).toEqual({ "secure:export": "secret-value" });
+    expect(storage.exportSecureUnsafe()).toEqual({
+      "secure:export": "secret-value",
+    });
+  });
 });
 
 describe("storage.clearBiometric", () => {

--- a/packages/react-native-nitro-storage/src/__tests__/web-storage.test.ts
+++ b/packages/react-native-nitro-storage/src/__tests__/web-storage.test.ts
@@ -113,6 +113,7 @@ function createWebBackendMock(name = "mock-backend") {
       };
     }),
     flush: jest.fn(async () => {}),
+    close: jest.fn(),
     emit,
   };
 }
@@ -2229,6 +2230,63 @@ describe("Web Storage", () => {
     storage.setEventObserver(undefined);
   });
 
+  it("redacts secure values for the global event observer by default on web", () => {
+    const events: unknown[] = [];
+
+    storage.setEventObserver((event) => {
+      events.push(event);
+    });
+
+    storage.setString("secure:event", "secret-value", StorageScope.Secure);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "key",
+      scope: StorageScope.Secure,
+      key: "secure:event",
+      oldValue: undefined,
+      newValue: "[secure]",
+    });
+
+    storage.setEventObserver(undefined);
+  });
+
+  it("allows explicit raw secure values for the global event observer on web", () => {
+    const events: unknown[] = [];
+
+    storage.setEventObserver(
+      (event) => {
+        events.push(event);
+      },
+      { redactSecureValues: false },
+    );
+
+    storage.setString("secure:event:raw", "secret-value", StorageScope.Secure);
+
+    expect(events[0]).toMatchObject({
+      type: "key",
+      scope: StorageScope.Secure,
+      key: "secure:event:raw",
+      newValue: "secret-value",
+    });
+
+    storage.setEventObserver(undefined);
+  });
+
+  it("requires explicit opt-in for secure raw export on web", () => {
+    storage.setString("secure:export", "secret-value", StorageScope.Secure);
+
+    expect(() => storage.export(StorageScope.Secure)).toThrow(
+      /exporting Secure scope exposes raw secret values/,
+    );
+    expect(
+      storage.export(StorageScope.Secure, { includeSecureValues: true }),
+    ).toEqual({ "secure:export": "secret-value" });
+    expect(storage.exportSecureUnsafe()).toEqual({
+      "secure:export": "secret-value",
+    });
+  });
+
   // --- clearBiometric ---
 
   it("storage.clearBiometric removes all __bio_ prefixed entries", () => {
@@ -2566,6 +2624,24 @@ describe("web backend switching", () => {
     const backend = getWebSecureStorageBackend();
     expect(backend).toBeDefined();
     expect(backend).not.toBe(custom);
+    expect(custom.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes replaced web storage backends", () => {
+    const firstSecure = createWebBackendMock("first-secure");
+    const nextSecure = createWebBackendMock("next-secure");
+    const firstDisk = createWebBackendMock("first-disk");
+    const nextDisk = createWebBackendMock("next-disk");
+
+    setWebSecureStorageBackend(firstSecure);
+    setWebSecureStorageBackend(nextSecure);
+    setWebDiskStorageBackend(firstDisk);
+    setWebDiskStorageBackend(nextDisk);
+
+    expect(firstSecure.close).toHaveBeenCalledTimes(1);
+    expect(nextSecure.close).not.toHaveBeenCalled();
+    expect(firstDisk.close).toHaveBeenCalledTimes(1);
+    expect(nextDisk.close).not.toHaveBeenCalled();
   });
 
   it("getWebDiskStorageBackend returns default backend when reset to undefined", () => {

--- a/packages/react-native-nitro-storage/src/index.ts
+++ b/packages/react-native-nitro-storage/src/index.ts
@@ -55,6 +55,8 @@ export type {
   StorageKeyChangeEvent,
 } from "./storage-events";
 export type {
+  WebDiskStorageBackend,
+  WebSecureStorageBackend,
   WebStorageBackend,
   WebStorageChangeEvent,
   WebStorageScope,
@@ -76,6 +78,12 @@ export type StorageMetricsEvent = {
   keysCount: number;
 };
 export type StorageMetricsObserver = (event: StorageMetricsEvent) => void;
+export type StorageEventObserverOptions = {
+  redactSecureValues?: boolean;
+};
+export type StorageExportOptions = {
+  includeSecureValues?: boolean;
+};
 export type StorageMetricSummary = {
   count: number;
   totalDurationMs: number;
@@ -229,6 +237,7 @@ const suppressedNativeEvents = new Map<NonMemoryScope, Map<string, number>>([
 ]);
 let metricsObserver: StorageMetricsObserver | undefined;
 let eventObserver: StorageEventListener | undefined;
+let eventObserverRedactSecureValues = true;
 const metricsCounters = new Map<
   string,
   { count: number; totalDurationMs: number; maxDurationMs: number }
@@ -411,6 +420,49 @@ function hasStorageChangeObservers(scope: StorageScope): boolean {
   return storageEvents.hasListeners(scope) || eventObserver !== undefined;
 }
 
+function shouldReadPreviousEventValues(scope: StorageScope): boolean {
+  if (storageEvents.hasListeners(scope)) {
+    return true;
+  }
+  if (!eventObserver) {
+    return false;
+  }
+  return scope !== StorageScope.Secure || !eventObserverRedactSecureValues;
+}
+
+const SECURE_EVENT_REDACTED_VALUE = "[secure]";
+
+function redactSecureKeyChange(
+  event: StorageKeyChangeEvent,
+): StorageKeyChangeEvent {
+  if (event.scope !== StorageScope.Secure) {
+    return event;
+  }
+
+  return {
+    ...event,
+    oldValue:
+      event.oldValue === undefined ? undefined : SECURE_EVENT_REDACTED_VALUE,
+    newValue:
+      event.newValue === undefined ? undefined : SECURE_EVENT_REDACTED_VALUE,
+  };
+}
+
+function eventForGlobalObserver(event: StorageChangeEvent): StorageChangeEvent {
+  if (!eventObserverRedactSecureValues || event.scope !== StorageScope.Secure) {
+    return event;
+  }
+
+  if (event.type === "key") {
+    return redactSecureKeyChange(event);
+  }
+
+  return {
+    ...event,
+    changes: event.changes.map(redactSecureKeyChange),
+  };
+}
+
 function emitKeyChange(
   scope: StorageScope,
   key: string,
@@ -436,7 +488,7 @@ function emitKeyChange(
     source,
   );
   storageEvents.emitKey(event);
-  eventObserver?.(event);
+  eventObserver?.(eventForGlobalObserver(event));
 }
 
 function emitBatchChange(
@@ -466,7 +518,7 @@ function emitBatchChange(
     changes,
   };
   storageEvents.emitBatch(event);
-  eventObserver?.(event);
+  eventObserver?.(eventForGlobalObserver(event));
 }
 
 function readPendingSecureWrite(key: string): string | undefined {
@@ -811,8 +863,12 @@ export const storage = {
   ): (() => void) => {
     return storage.subscribePrefix(scope, prefixKey(namespace, ""), listener);
   },
-  setEventObserver: (observer?: StorageEventListener) => {
+  setEventObserver: (
+    observer?: StorageEventListener,
+    options: StorageEventObserverOptions = {},
+  ) => {
     eventObserver = observer;
+    eventObserverRedactSecureValues = options.redactSecureValues !== false;
     if (observer) {
       ensureNativeScopeSubscription(StorageScope.Disk);
       ensureNativeScopeSubscription(StorageScope.Secure);
@@ -823,7 +879,7 @@ export const storage = {
   },
   clear: (scope: StorageScope) => {
     measureOperation("storage:clear", scope, () => {
-      const previousValues = hasStorageChangeObservers(scope)
+      const previousValues = shouldReadPreviousEventValues(scope)
         ? storage.getAll(scope)
         : {};
       if (scope === StorageScope.Memory) {
@@ -927,7 +983,7 @@ export const storage = {
       }
 
       const keyPrefix = prefixKey(namespace, "");
-      const previousValues = hasStorageChangeObservers(scope)
+      const previousValues = shouldReadPreviousEventValues(scope)
         ? storage.getByPrefix(keyPrefix, scope)
         : {};
       if (scope === StorageScope.Disk) {
@@ -1077,9 +1133,24 @@ export const storage = {
       return result;
     });
   },
-  export: (scope: StorageScope): Record<string, string> => {
+  export: (
+    scope: StorageScope,
+    options: StorageExportOptions = {},
+  ): Record<string, string> => {
+    if (scope === StorageScope.Secure && options.includeSecureValues !== true) {
+      throw new Error(
+        "NitroStorage: exporting Secure scope exposes raw secret values. Pass { includeSecureValues: true } or use exportSecureUnsafe().",
+      );
+    }
     return measureOperation("storage:export", scope, () =>
       storage.getAll(scope),
+    );
+  },
+  exportSecureUnsafe: (): Record<string, string> => {
+    return measureOperation(
+      "storage:exportSecureUnsafe",
+      StorageScope.Secure,
+      () => storage.getAll(StorageScope.Secure),
     );
   },
   size: (scope: StorageScope): number => {
@@ -2136,7 +2207,7 @@ export function setBatch<T>(
         flushSecureWrites();
         const storageModule = getStorageModule();
         const keys = secureEntries.map(({ item }) => item.key);
-        const oldValues = hasStorageChangeObservers(scope)
+        const oldValues = shouldReadPreviousEventValues(scope)
           ? (storageModule.getBatch(keys, scope) ?? [])
           : [];
         const groupedByAccessControl = new Map<
@@ -2193,7 +2264,7 @@ export function setBatch<T>(
 
       const keys = items.map((entry) => entry.item.key);
       const values = items.map((entry) => entry.item.serialize(entry.value));
-      const oldValues = hasStorageChangeObservers(scope)
+      const oldValues = shouldReadPreviousEventValues(scope)
         ? (getStorageModule().getBatch(keys, scope) ?? [])
         : [];
 
@@ -2252,7 +2323,7 @@ export function removeBatch(
       if (scope === StorageScope.Secure) {
         flushSecureWrites();
       }
-      const oldValues = hasStorageChangeObservers(scope)
+      const oldValues = shouldReadPreviousEventValues(scope)
         ? (getStorageModule().getBatch(keys, scope) ?? [])
         : [];
       getStorageModule().removeBatch(keys, scope);

--- a/packages/react-native-nitro-storage/src/index.web.ts
+++ b/packages/react-native-nitro-storage/src/index.web.ts
@@ -54,6 +54,8 @@ export type {
   StorageKeyChangeEvent,
 } from "./storage-events";
 export type {
+  WebDiskStorageBackend,
+  WebSecureStorageBackend,
   WebStorageBackend,
   WebStorageChangeEvent,
   WebStorageScope,
@@ -75,6 +77,12 @@ export type StorageMetricsEvent = {
   keysCount: number;
 };
 export type StorageMetricsObserver = (event: StorageMetricsEvent) => void;
+export type StorageEventObserverOptions = {
+  redactSecureValues?: boolean;
+};
+export type StorageExportOptions = {
+  includeSecureValues?: boolean;
+};
 export type StorageMetricSummary = {
   count: number;
   totalDurationMs: number;
@@ -254,6 +262,7 @@ let hasWarnedAboutWebBiometricFallback = false;
 let hasWindowStorageEventSubscription = false;
 let metricsObserver: StorageMetricsObserver | undefined;
 let eventObserver: StorageEventListener | undefined;
+let eventObserverRedactSecureValues = true;
 const metricsCounters = new Map<
   string,
   { count: number; totalDurationMs: number; maxDurationMs: number }
@@ -552,6 +561,21 @@ function resetBackendChangeSubscription(scope: NonMemoryScope): void {
   externalSyncUnsubscribers.delete(scope);
 }
 
+function closeWebBackend(
+  scope: NonMemoryScope,
+  backend: WebStorageBackend | undefined,
+): void {
+  if (!backend?.close) {
+    return;
+  }
+
+  try {
+    backend.close();
+  } catch (error) {
+    throw createWebStorageError(scope, "close", error, backend);
+  }
+}
+
 function ensureExternalSyncSubscriptions(): void {
   if (
     !hasWindowStorageEventSubscription &&
@@ -675,6 +699,49 @@ function hasStorageChangeObservers(scope: StorageScope): boolean {
   return storageEvents.hasListeners(scope) || eventObserver !== undefined;
 }
 
+function shouldReadPreviousEventValues(scope: StorageScope): boolean {
+  if (storageEvents.hasListeners(scope)) {
+    return true;
+  }
+  if (!eventObserver) {
+    return false;
+  }
+  return scope !== StorageScope.Secure || !eventObserverRedactSecureValues;
+}
+
+const SECURE_EVENT_REDACTED_VALUE = "[secure]";
+
+function redactSecureKeyChange(
+  event: StorageKeyChangeEvent,
+): StorageKeyChangeEvent {
+  if (event.scope !== StorageScope.Secure) {
+    return event;
+  }
+
+  return {
+    ...event,
+    oldValue:
+      event.oldValue === undefined ? undefined : SECURE_EVENT_REDACTED_VALUE,
+    newValue:
+      event.newValue === undefined ? undefined : SECURE_EVENT_REDACTED_VALUE,
+  };
+}
+
+function eventForGlobalObserver(event: StorageChangeEvent): StorageChangeEvent {
+  if (!eventObserverRedactSecureValues || event.scope !== StorageScope.Secure) {
+    return event;
+  }
+
+  if (event.type === "key") {
+    return redactSecureKeyChange(event);
+  }
+
+  return {
+    ...event,
+    changes: event.changes.map(redactSecureKeyChange),
+  };
+}
+
 function emitKeyChange(
   scope: StorageScope,
   key: string,
@@ -692,7 +759,7 @@ function emitKeyChange(
     source,
   );
   storageEvents.emitKey(event);
-  eventObserver?.(event);
+  eventObserver?.(eventForGlobalObserver(event));
 }
 
 function emitBatchChange(
@@ -713,7 +780,7 @@ function emitBatchChange(
     changes,
   };
   storageEvents.emitBatch(event);
-  eventObserver?.(event);
+  eventObserver?.(eventForGlobalObserver(event));
 }
 
 function readPendingSecureWrite(key: string): string | undefined {
@@ -1293,15 +1360,19 @@ export const storage = {
   ): (() => void) => {
     return storage.subscribePrefix(scope, prefixKey(namespace, ""), listener);
   },
-  setEventObserver: (observer?: StorageEventListener) => {
+  setEventObserver: (
+    observer?: StorageEventListener,
+    options: StorageEventObserverOptions = {},
+  ) => {
     eventObserver = observer;
+    eventObserverRedactSecureValues = options.redactSecureValues !== false;
     if (observer) {
       ensureExternalSyncSubscriptions();
     }
   },
   clear: (scope: StorageScope) => {
     measureOperation("storage:clear", scope, () => {
-      const previousValues = hasStorageChangeObservers(scope)
+      const previousValues = shouldReadPreviousEventValues(scope)
         ? storage.getAll(scope)
         : {};
       if (scope === StorageScope.Memory) {
@@ -1405,7 +1476,7 @@ export const storage = {
       }
 
       const keyPrefix = prefixKey(namespace, "");
-      const previousValues = hasStorageChangeObservers(scope)
+      const previousValues = shouldReadPreviousEventValues(scope)
         ? storage.getByPrefix(keyPrefix, scope)
         : {};
       if (scope === StorageScope.Disk) {
@@ -1551,9 +1622,24 @@ export const storage = {
       return result;
     });
   },
-  export: (scope: StorageScope): Record<string, string> => {
+  export: (
+    scope: StorageScope,
+    options: StorageExportOptions = {},
+  ): Record<string, string> => {
+    if (scope === StorageScope.Secure && options.includeSecureValues !== true) {
+      throw new Error(
+        "NitroStorage: exporting Secure scope exposes raw secret values. Pass { includeSecureValues: true } or use exportSecureUnsafe().",
+      );
+    }
     return measureOperation("storage:export", scope, () =>
       storage.getAll(scope),
+    );
+  },
+  exportSecureUnsafe: (): Record<string, string> => {
+    return measureOperation(
+      "storage:exportSecureUnsafe",
+      StorageScope.Secure,
+      () => storage.getAll(StorageScope.Secure),
     );
   },
   size: (scope: StorageScope): number => {
@@ -1759,12 +1845,17 @@ export const storage = {
 export function setWebSecureStorageBackend(
   backend?: WebSecureStorageBackend,
 ): void {
+  const previousBackend = webSecureStorageBackend;
+  const nextBackend = backend ?? createDefaultSecureBackend();
   pendingSecureWrites.clear();
-  webSecureStorageBackend = backend ?? createDefaultSecureBackend();
   resetBackendChangeSubscription(StorageScope.Secure);
+  webSecureStorageBackend = nextBackend;
   hydratedWebScopeKeyIndex.delete(StorageScope.Secure);
   clearScopeRawCache(StorageScope.Secure);
   ensureExternalSyncSubscriptions();
+  if (previousBackend !== nextBackend) {
+    closeWebBackend(StorageScope.Secure, previousBackend);
+  }
 }
 
 export function getWebSecureStorageBackend():
@@ -1776,12 +1867,17 @@ export function getWebSecureStorageBackend():
 export function setWebDiskStorageBackend(
   backend?: WebDiskStorageBackend,
 ): void {
+  const previousBackend = webDiskStorageBackend;
+  const nextBackend = backend ?? createDefaultDiskBackend();
   pendingDiskWrites.clear();
-  webDiskStorageBackend = backend ?? createDefaultDiskBackend();
   resetBackendChangeSubscription(StorageScope.Disk);
+  webDiskStorageBackend = nextBackend;
   hydratedWebScopeKeyIndex.delete(StorageScope.Disk);
   clearScopeRawCache(StorageScope.Disk);
   ensureExternalSyncSubscriptions();
+  if (previousBackend !== nextBackend) {
+    closeWebBackend(StorageScope.Disk, previousBackend);
+  }
 }
 
 export function getWebDiskStorageBackend(): WebDiskStorageBackend | undefined {
@@ -2597,7 +2693,7 @@ export function setBatch<T>(
 
         flushSecureWrites();
         const keys = secureEntries.map(({ item }) => item.key);
-        const oldValues = hasStorageChangeObservers(scope)
+        const oldValues = shouldReadPreviousEventValues(scope)
           ? WebStorage.getBatch(keys, scope)
           : [];
         const groupedByAccessControl = new Map<
@@ -2654,7 +2750,7 @@ export function setBatch<T>(
 
       const keys = items.map((entry) => entry.item.key);
       const values = items.map((entry) => entry.item.serialize(entry.value));
-      const oldValues = hasStorageChangeObservers(scope)
+      const oldValues = shouldReadPreviousEventValues(scope)
         ? WebStorage.getBatch(keys, scope)
         : [];
       WebStorage.setBatch(keys, values, scope);
@@ -2712,7 +2808,7 @@ export function removeBatch(
       if (scope === StorageScope.Secure) {
         flushSecureWrites();
       }
-      const oldValues = hasStorageChangeObservers(scope)
+      const oldValues = shouldReadPreviousEventValues(scope)
         ? WebStorage.getBatch(keys, scope)
         : [];
       WebStorage.removeBatch(keys, scope);

--- a/packages/react-native-nitro-storage/src/indexeddb-backend.ts
+++ b/packages/react-native-nitro-storage/src/indexeddb-backend.ts
@@ -74,6 +74,7 @@ export async function createIndexedDBBackend(
   const pendingWrites = new Set<Promise<void>>();
   const pendingErrors: Error[] = [];
   const subscribers = new Set<(event: WebStorageChangeEvent) => void>();
+  let closed = false;
   const sourceId = `nitro-storage-${Math.random().toString(36).slice(2)}`;
   const channelName =
     options.channelName ?? `nitro-storage:${dbName}:${storeName}`;
@@ -81,6 +82,12 @@ export async function createIndexedDBBackend(
     typeof BroadcastChannel !== "undefined"
       ? new BroadcastChannel(channelName)
       : null;
+
+  function assertOpen(): void {
+    if (closed) {
+      throw new Error(`IndexedDB backend "${dbName}/${storeName}" is closed.`);
+    }
+  }
 
   function emitExternal(event: WebStorageChangeEvent): void {
     subscribers.forEach((subscriber) => {
@@ -98,6 +105,10 @@ export async function createIndexedDBBackend(
   }
 
   channel?.addEventListener("message", (event: MessageEvent) => {
+    if (closed) {
+      return;
+    }
+
     const data = event.data as
       | (WebStorageChangeEvent & { sourceId?: string })
       | undefined;
@@ -209,34 +220,41 @@ export async function createIndexedDBBackend(
   const backend: WebSecureStorageBackend = {
     name: `indexeddb:${dbName}/${storeName}`,
     getItem(key: string): string | null {
+      assertOpen();
       return cache.get(key) ?? null;
     },
 
     setItem(key: string, value: string): void {
+      assertOpen();
       cache.set(key, value);
       persistSet(key, value);
       publish({ key, newValue: value });
     },
 
     removeItem(key: string): void {
+      assertOpen();
       cache.delete(key);
       persistDelete(key);
       publish({ key, newValue: null });
     },
 
     clear(): void {
+      assertOpen();
       cache.clear();
       persistClear();
       publish({ key: null, newValue: null });
     },
 
     getAllKeys(): string[] {
+      assertOpen();
       return Array.from(cache.keys());
     },
     getMany(keys: string[]): (string | null)[] {
+      assertOpen();
       return keys.map((key) => cache.get(key) ?? null);
     },
     setMany(entries): void {
+      assertOpen();
       entries.forEach(([key, value]) => {
         cache.set(key, value);
       });
@@ -253,6 +271,7 @@ export async function createIndexedDBBackend(
       }
     },
     removeMany(keys: string[]): void {
+      assertOpen();
       keys.forEach((key) => {
         cache.delete(key);
       });
@@ -269,9 +288,11 @@ export async function createIndexedDBBackend(
       }
     },
     size(): number {
+      assertOpen();
       return cache.size;
     },
     subscribe(listener): () => void {
+      assertOpen();
       subscribers.add(listener);
       return () => {
         subscribers.delete(listener);
@@ -285,6 +306,15 @@ export async function createIndexedDBBackend(
 
       const [error] = pendingErrors.splice(0);
       throw error;
+    },
+    close(): void {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      subscribers.clear();
+      channel?.close();
+      db.close();
     },
   };
 

--- a/packages/react-native-nitro-storage/src/web-storage-backend.ts
+++ b/packages/react-native-nitro-storage/src/web-storage-backend.ts
@@ -21,6 +21,7 @@ export type WebStorageBackend = {
   size?: () => number;
   subscribe?: (listener: (event: WebStorageChangeEvent) => void) => () => void;
   flush?: () => Promise<void>;
+  close?: () => void;
   name?: string;
 };
 

--- a/packages/react-native-nitro-storage/type-tests/public-api.test.ts
+++ b/packages/react-native-nitro-storage/type-tests/public-api.test.ts
@@ -6,6 +6,10 @@ import {
   type SecurityCapabilities,
   type StorageMetricsEvent,
   type StorageMetricsObserver,
+  type StorageEventObserverOptions,
+  type StorageExportOptions,
+  type WebDiskStorageBackend,
+  type WebSecureStorageBackend,
   createSecureAuthStorage,
   createStorageItem,
   getWebSecureStorageBackend,
@@ -80,7 +84,9 @@ const prefixedEntriesRecord: Record<string, string> = prefixedEntries;
 void prefixedKeysArray;
 void prefixedEntriesRecord;
 
-const metricsObserver: StorageMetricsObserver = (event: StorageMetricsEvent) => {
+const metricsObserver: StorageMetricsObserver = (
+  event: StorageMetricsEvent,
+) => {
   const operationName: string = event.operation;
   void operationName;
 };
@@ -88,6 +94,11 @@ storage.setMetricsObserver(metricsObserver);
 storage.getMetricsSnapshot();
 storage.resetMetrics();
 storage.setMetricsObserver(undefined);
+const observerOptions: StorageEventObserverOptions = {
+  redactSecureValues: true,
+};
+storage.setEventObserver(() => {}, observerOptions);
+storage.setEventObserver(undefined);
 
 storage.setAccessControl(AccessControl.WhenUnlockedThisDeviceOnly);
 storage.setSecureWritesAsync(true);
@@ -100,9 +111,27 @@ const secureMetadata: SecureStorageMetadata =
   storage.getSecureMetadata("auth:accessToken");
 const secureMetadataList: SecureStorageMetadata[] =
   storage.getAllSecureMetadata();
+const exportOptions: StorageExportOptions = { includeSecureValues: true };
+const secureExport: Record<string, string> = storage.export(
+  StorageScope.Secure,
+  exportOptions,
+);
+const secureUnsafeExport: Record<string, string> = storage.exportSecureUnsafe();
 void securityCapabilities;
 void secureMetadata;
 void secureMetadataList;
+void secureExport;
+void secureUnsafeExport;
+
+const typedWebDiskBackend: WebDiskStorageBackend = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+  clear: () => {},
+  getAllKeys: () => [],
+};
+const typedWebSecureBackend: WebSecureStorageBackend = typedWebDiskBackend;
+void typedWebSecureBackend;
 
 setWebSecureStorageBackend(undefined);
 getWebSecureStorageBackend();


### PR DESCRIPTION
# Summary
Prepare react-native-nitro-storage 0.5.5 with secure export guardrails, stronger public TypeScript coverage, refreshed docs, and example parity across web, Android, and iOS.

# Changes
- Add explicit Secure export opt-in and `exportSecureUnsafe()` for migration-only raw Secure snapshots.
- Redact Secure values in `storage.setEventObserver()` by default, with a typed raw-value opt-in.
- Export typed web backend contracts and close replaced IndexedDB/web backend handles.
- Add Expo Android backup exclusions for Nitro Storage secure preference files.
- Align README, CHANGELOG, package docs, type tests, and example UI with the current API surface.
- Ignore generated `.cxx` and Bun `node_modules/.old-*` watcher churn in Watchman/Metro.
- Bump release version to 0.5.5 and align Nitro/tooling pins.