### PR TITLE
Release v0.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented in this file.
 
 The format follows Keep a Changelog and the project adheres to SemVer.
 
+## 0.5.9 - 2026-06-11
+
+### Fixed
+
+- Added a package-owned Android manifest initializer so storage setup no longer requires generated `MainApplication` edits in Expo or bare React Native apps.
+- Tied the Expo config plugin run-once metadata to the package version so updated package plugin behavior is reapplied correctly after package upgrades.
+
+### Changed
+
+- Included `CHANGELOG.md` in the packed package docs.
+
 ## 0.5.8 - 2026-06-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ Add the config plugin before prebuilding native iOS and Android projects:
 | `addBiometricPermissions` | `false`                  | Adds Android biometric and fingerprint permissions.            |
 | `configureAndroidBackup`  | `true`                   | Writes Android backup rules that exclude secure storage files. |
 
-The plugin also initializes the Android storage adapter in `MainApplication`.
-Set `configureAndroidBackup: false` only when your app maintains equivalent
-backup and device-transfer exclusions for Nitro Storage secure files.
+Android adapter initialization is owned by the package through an Android
+manifest initializer, so apps should not edit `MainApplication` to call
+`AndroidStorageAdapter.init(this)`. Set `configureAndroidBackup: false` only
+when your app maintains equivalent backup and device-transfer exclusions for
+Nitro Storage secure files.
 
 ## Quick Start
 
@@ -380,6 +382,8 @@ Secure scope is only as strong as the backend you configure.
 
 - **Expo Go error:** build a development client; Expo Go cannot load Nitro
   modules.
+- **Android not initialized:** rebuild the native app after installing or
+  upgrading the package so the Android manifest initializer is merged.
 - **Secure values fail after Android restore:** keep `configureAndroidBackup:
 true` or provide equivalent backup exclusions.
 - **Biometric prompt does not appear:** set `biometric: true` on the item and

--- a/packages/react-native-nitro-storage/android/src/main/AndroidManifest.xml
+++ b/packages/react-native-nitro-storage/android/src/main/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application>
+    <provider
+      android:name="com.nitrostorage.NitroStorageInitializer"
+      android:authorities="${applicationId}.nitrostorage-initializer"
+      android:exported="false"
+      android:initOrder="100" />
+  </application>
+</manifest>

--- a/packages/react-native-nitro-storage/android/src/main/java/com/nitrostorage/NitroStorageInitializer.kt
+++ b/packages/react-native-nitro-storage/android/src/main/java/com/nitrostorage/NitroStorageInitializer.kt
@@ -1,0 +1,38 @@
+package com.nitrostorage
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+
+class NitroStorageInitializer : ContentProvider() {
+  override fun onCreate(): Boolean {
+    context?.applicationContext?.let(AndroidStorageAdapter::init)
+    return true
+  }
+
+  override fun query(
+    uri: Uri,
+    projection: Array<out String>?,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+    sortOrder: String?,
+  ): Cursor? = null
+
+  override fun getType(uri: Uri): String? = null
+
+  override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+  override fun delete(
+    uri: Uri,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+  ): Int = 0
+
+  override fun update(
+    uri: Uri,
+    values: ContentValues?,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+  ): Int = 0
+}

--- a/packages/react-native-nitro-storage/app.plugin.js
+++ b/packages/react-native-nitro-storage/app.plugin.js
@@ -1,12 +1,12 @@
 const {
   withInfoPlist,
   withAndroidManifest,
-  withMainApplication,
   withDangerousMod,
   createRunOncePlugin,
 } = require("@expo/config-plugins");
 const fs = require("fs");
 const path = require("path");
+const pkg = require("./package.json");
 
 const DATA_EXTRACTION_RULES_RESOURCE =
   "@xml/nitro_storage_data_extraction_rules";
@@ -152,57 +152,13 @@ const withNitroStorage = (config, props = {}) => {
     ]);
   }
 
-  config = withMainApplication(config, (config) => {
-    const { modResults } = config;
-    const { language, contents } = modResults;
-
-    if (language === "java") {
-      if (!contents.includes("AndroidStorageAdapter.init")) {
-        const importStatement =
-          "import com.nitrostorage.AndroidStorageAdapter;";
-        const initStatement = "    AndroidStorageAdapter.init(this);";
-
-        if (!contents.includes(importStatement)) {
-          modResults.contents = contents.replace(
-            /(package .*;\n)/,
-            `$1\n${importStatement}\n`,
-          );
-        }
-
-        modResults.contents = modResults.contents.replace(
-          /(super\.onCreate\(\);)/,
-          `$1\n${initStatement}`,
-        );
-      }
-    } else if (language === "kt") {
-      if (!contents.includes("AndroidStorageAdapter.init")) {
-        const importStatement = "import com.nitrostorage.AndroidStorageAdapter";
-        const initStatement = "    AndroidStorageAdapter.init(this)";
-
-        if (!contents.includes(importStatement)) {
-          modResults.contents = contents.replace(
-            /(package .*\n)/,
-            `$1\n${importStatement}\n`,
-          );
-        }
-
-        modResults.contents = modResults.contents.replace(
-          /(super\.onCreate\(\))/,
-          `$1\n${initStatement}`,
-        );
-      }
-    }
-
-    return config;
-  });
-
   return config;
 };
 
 module.exports = createRunOncePlugin(
   withNitroStorage,
-  "react-native-nitro-storage",
-  "1.0.0",
+  pkg.name,
+  pkg.version,
 );
 module.exports.withNitroStorage = withNitroStorage;
 module.exports._internal = {

--- a/packages/react-native-nitro-storage/package.json
+++ b/packages/react-native-nitro-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-storage",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Synchronous React Native storage powered by Nitro Modules and JSI: typed Memory, Disk, Keychain/Android Keystore secure storage, biometric auth, MMKV migration, Expo, Zustand/Jotai persistence, and web IndexedDB support.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -33,6 +33,7 @@
     "docs",
     "nitrogen",
     "nitro.json",
+    "CHANGELOG.md",
     "*.podspec",
     "SECURITY.md",
     "app.plugin.js",

--- a/packages/react-native-nitro-storage/scripts/sync-package-docs.js
+++ b/packages/react-native-nitro-storage/scripts/sync-package-docs.js
@@ -6,6 +6,7 @@ const repoRoot = path.resolve(packageRoot, "../..");
 
 const entries = [
   { source: "README.md", target: "README.md", type: "file" },
+  { source: "CHANGELOG.md", target: "CHANGELOG.md", type: "file" },
   { source: "LICENSE", target: "LICENSE", type: "file" },
   { source: "SECURITY.md", target: "SECURITY.md", type: "file" },
   { source: "docs", target: "docs", type: "directory" },

--- a/packages/react-native-nitro-storage/src/__tests__/app-plugin.test.js
+++ b/packages/react-native-nitro-storage/src/__tests__/app-plugin.test.js
@@ -90,4 +90,30 @@ describe("Expo config plugin", () => {
       fs.rmSync(projectRoot, { recursive: true, force: true });
     }
   });
+
+  it("registers the package initializer provider in the Android manifest", () => {
+    const packageRoot = path.resolve(__dirname, "../..");
+    const manifest = fs.readFileSync(
+      path.join(packageRoot, "android/src/main/AndroidManifest.xml"),
+      "utf8",
+    );
+
+    expect(manifest).toContain("com.nitrostorage.NitroStorageInitializer");
+    expect(manifest).toContain("${applicationId}.nitrostorage-initializer");
+  });
+
+  it("initializes the Android adapter from application context", () => {
+    const packageRoot = path.resolve(__dirname, "../..");
+    const initializer = fs.readFileSync(
+      path.join(
+        packageRoot,
+        "android/src/main/java/com/nitrostorage/NitroStorageInitializer.kt",
+      ),
+      "utf8",
+    );
+
+    expect(initializer).toContain(
+      "context?.applicationContext?.let(AndroidStorageAdapter::init)",
+    );
+  });
 });


### PR DESCRIPTION
# Changes
- Add an Android manifest initializer so storage setup no longer requires `MainApplication` edits.
- Keep the Expo config plugin focused on Face ID text, biometric permissions, backup rules, and versioned run-once metadata.
- Include `CHANGELOG.md` in packed package docs and update README troubleshooting/setup guidance.
- Add initializer coverage alongside existing plugin backup-rule tests.
