### PR TITLE
Storage 0.8.1: auth-token README recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented in this file.
 
 The format follows Keep a Changelog and the project adheres to SemVer.
 
+## 0.8.1 - 2026-08-13
+
+### Breaking changes
+
+- None.
+
+### Changed
+
+- README now leads with `createSecureAuthStorage` and `renameFrom` as the
+  auth-token recipe. `getString` / `setString` stay the raw API.
+
 ## 0.8.0 - 2026-08-12
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ pagination, conflict resolution, or remote synchronization.
 - [Install](#install)
 - [Expo Config](#expo-config)
 - [Quick Start](#quick-start)
+- [Auth Tokens](#auth-tokens)
 - [Typed Storage Items](#typed-storage-items)
 - [Item Ergonomics](#item-ergonomics)
 - [Set Items](#set-items)
@@ -128,6 +129,35 @@ themeItem.set("dark");
 const theme = themeItem.get();
 const raw = storage.getString("settings:theme", StorageScope.Disk);
 ```
+
+`storage.getString` / `setString` remain the raw API. Prefer typed items for
+application state.
+
+## Auth Tokens
+
+Use `createSecureAuthStorage` for access and refresh tokens. `renameFrom`
+copies a legacy key on first read and deletes it, so you do not need a custom
+migration helper.
+
+```ts
+import { createSecureAuthStorage } from "react-native-nitro-storage";
+
+const auth = createSecureAuthStorage(
+  {
+    accessToken: { renameFrom: "authToken" },
+    refreshToken: { renameFrom: "refreshToken" },
+  },
+  { namespace: "auth", fallbackToCacheOnReadError: true },
+);
+
+auth.accessToken.set("access-token");
+const current = auth.accessToken.get();
+auth.accessToken.subscribe(() => {});
+```
+
+Keep `getString` facades only when the app owns a storage architecture
+boundary. `createSecureAuthStorage` already namespaces keys, notifies
+subscribers, and migrates legacy keys.
 
 ## Typed Storage Items
 

--- a/packages/react-native-nitro-storage/package.json
+++ b/packages/react-native-nitro-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-storage",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Synchronous React Native storage powered by Nitro Modules and JSI: typed Memory, Disk, Keychain/Android Keystore secure storage, biometric auth, MMKV migration, Expo, Zustand/Jotai persistence, and web IndexedDB support.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",


### PR DESCRIPTION
# Summary

Lead the README with `createSecureAuthStorage` and `renameFrom` as the auth-token recipe. Raw `getString` / `setString` stay.

# Changes

- Add an Auth Tokens section after Quick Start covering `createSecureAuthStorage` and `renameFrom`.
- Bump to 0.8.1. Breaking changes: none.