### PR TITLE
Release v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes are always listed first in each release section.
 
+## [0.10.2] - 2026-09-10
+
+### Breaking changes
+
+- None.
+
+### Fixed
+
+- iOS builds using static frameworks and source-built React Native now resolve
+  Folly and React Native headers when compiling the Nitro Swift/C++ bridge.
+
 ## [0.10.1] - 2026-09-09
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ before installing this package, then rebuild the native app so the generated
 Nitro bindings and native runtime use the same major-minor version:
 
 ```sh
-bun add react-native-nitro-modules@0.37.1 react-native-nitro-storage@0.10.1
+bun add react-native-nitro-modules@0.37.1 react-native-nitro-storage@0.10.2
 bunx expo prebuild
 ```
 
@@ -98,6 +98,10 @@ bunx expo prebuild
 
 Expo Go cannot load Nitro native modules. Use an Expo development build or a
 bare React Native app.
+
+iOS static frameworks are supported with source-built React Native. After
+upgrading, regenerate the Expo native project or run `pod install`, then rebuild
+the app so CocoaPods applies the updated header paths.
 
 ## Expo Config
 

--- a/maestro/smoke-tests.yaml
+++ b/maestro/smoke-tests.yaml
@@ -10,9 +10,9 @@ name: "Smoke Tests - Terminal State"
     timeout: 120000
 - tapOn: "Run All"
 - extendedWaitUntil:
-    notVisible: "Running..."
+    visible:
+      id: "smoke-summary"
+      text: "Complete: PASS: [1-9][0-9]*/[0-9]+ passed · 0 failed.*"
     timeout: 120000
-- assertVisible:
-    text: ".*[1-9][0-9]*/[0-9]+ passed.*"
 - assertNotVisible:
-    text: ".*failed.*"
+    text: "Complete: FAIL.*"

--- a/packages/react-native-nitro-storage/package.json
+++ b/packages/react-native-nitro-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-storage",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Synchronous React Native storage powered by Nitro Modules and JSI: typed Memory, Disk, Keychain/Android Keystore secure storage, biometric auth, MMKV migration, Expo, Zustand/Jotai persistence, and web IndexedDB support.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/react-native-nitro-storage/react-native-nitro-storage.podspec
+++ b/packages/react-native-nitro-storage/react-native-nitro-storage.podspec
@@ -39,4 +39,5 @@ Pod::Spec.new do |s|
   
   load 'nitrogen/generated/ios/NitroStorage+autolinking.rb'
   add_nitrogen_files(s)
+  install_modules_dependencies(s)
 end


### PR DESCRIPTION
# Summary

Fix iOS compilation with static frameworks and source-built React Native in react-native-nitro-storage 0.10.2.

# Changes

- Apply React Native dependency configuration after Nitro autolinking so the Swift/C++ bridge can resolve Folly and React Native headers.
- Update the patch version, changelog, and iOS rebuild guidance.
